### PR TITLE
Test patch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pyrovision
+psutil

--- a/test/fake_gpiozero.py
+++ b/test/fake_gpiozero.py
@@ -6,6 +6,6 @@
 
 class CPUTemperature:
 
-	def __init__(self):
-		print("using fake CPUTemperature")
-		self.temperature = 40
+    def __init__(self):
+        print("using fake CPUTemperature")
+        self.temperature = 40

--- a/test/fake_gpiozero.py
+++ b/test/fake_gpiozero.py
@@ -1,0 +1,11 @@
+# Copyright (C) 2021, Pyronear contributors.
+
+# This program is licensed under the GNU Affero General Public License version 3.
+# See LICENSE or go to <https://www.gnu.org/licenses/agpl-3.0.txt> for full license details.
+
+
+class CPUTemperature:
+
+	def __init__(self):
+		print("using fake CPUTemperature")
+		self.temperature = 40

--- a/test/pi_patch.py
+++ b/test/pi_patch.py
@@ -1,0 +1,10 @@
+# Copyright (C) 2021, Pyronear contributors.
+
+# This program is licensed under the GNU Affero General Public License version 3.
+# See LICENSE or go to <https://www.gnu.org/licenses/agpl-3.0.txt> for full license details.
+
+import sys
+import fake_gpiozero
+
+
+sys.modules['gpiozero'] = fake_gpiozero 

--- a/test/test_raspberryPi_monitorPi.py
+++ b/test/test_raspberryPi_monitorPi.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 from pathlib import Path
 import os
 import pandas as pd
-from pyronearEngine.raspberryPi.monitorPi import MonitorPi
+from pyroengine.raspberryPi.monitorPi import MonitorPi
 
 
 class MonitorPiTester(unittest.TestCase):

--- a/test/test_raspberryPi_monitorPi.py
+++ b/test/test_raspberryPi_monitorPi.py
@@ -15,17 +15,17 @@ from pyroengine.raspberryPi.monitorPi import MonitorPi
 
 class MonitorPiTester(unittest.TestCase):
 
-    @patch('pyronearEngine.raspberryPi.monitorPi.psutil')
+    @patch('pyroengine.raspberryPi.monitorPi.psutil')
     def setUp(self, mock_psutil):
 
-        self.monitoringFolder = Path(__file__).parent / 'fixtures'
+        self.monitoringFolder = Path(__file__).parent
         self.logFile = "pi_perf_example.csv"
         self.path_file = os.path.join(self.monitoringFolder, self.logFile)
 
         def prepare_get_record(self):
 
             with patch.object(MonitorPi, "__init__", lambda x, y, z: None):
-                with patch('pyronearEngine.raspberryPi.monitorPi.strftime') as mock_strftime:
+                with patch('pyroengine.raspberryPi.monitorPi.strftime') as mock_strftime:
                     mock_strftime.return_value = '2020-04-01 12:34:56'
 
                     # add "attributes" to psutil mock
@@ -49,7 +49,7 @@ class MonitorPiTester(unittest.TestCase):
 
         prepare_get_record(self)
 
-    @patch('pyronearEngine.raspberryPi.monitorPi.psutil')
+    @patch('pyroengine.raspberryPi.monitorPi.psutil')
     def test_MonitorPi_create_logfile(self, mock_psutil):
         self.assertTrue(os.path.exists(self.path_file), "file does not exist")
 
@@ -57,7 +57,7 @@ class MonitorPiTester(unittest.TestCase):
         the_record = pd.read_csv(self.path_file)
         pd.testing.assert_frame_equal(pd.DataFrame(data=self.the_test_line), the_record)
 
-    @patch('pyronearEngine.raspberryPi.monitorPi.psutil')
+    @patch('pyroengine.raspberryPi.monitorPi.psutil')
     def test_MonitorPi_update_logFile(self, mock_psutil):
         with patch.object(MonitorPi, "__init__", lambda x, y, z: None):
             mock_psutil.cpu_percent.return_value = 11

--- a/test/test_raspberryPi_monitorPi.py
+++ b/test/test_raspberryPi_monitorPi.py
@@ -4,6 +4,7 @@
 # This file is dual licensed under the terms of the CeCILL-2.1 and AGPLv3 licenses.
 # See the LICENSE file in the root of this repository for complete details.
 
+import pi_patch
 import unittest
 from unittest.mock import Mock, patch
 from pathlib import Path


### PR DESCRIPTION
Following the discussions in #5 I propose you the following solution inspired by this repo : https://pypi.org/project/fake-rpi/
We create fakes Raspberry pi library classes for the tests, and we use the pi_patch module to replace the real ones by the fake ones during the tests. I find this solution quite elegant and it solves our problem. It's not perfect because we don't reproduce the exact working conditions but it's similar

What do you think ?