### PR TITLE
Allow webserver pyroengine use

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -6,5 +6,6 @@ services:
       context: ..
       dockerfile: ./server/src/Dockerfile
     command: uvicorn server.src.app.main:app --reload --workers 1 --host 0.0.0.0 --port 8000
+    restart: always
     ports:
       - ${PORT}:8000

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -2,9 +2,9 @@ version: '3.7'
 
 services:
   web:
-    build: ./src
-    command: uvicorn app.main:app --reload --workers 1 --host 0.0.0.0 --port 8000
-    volumes:
-      - ./src/:/usr/src/app/
+    build:
+      context: ..
+      dockerfile: ./server/src/Dockerfile
+    command: uvicorn server.src.app.main:app --reload --workers 1 --host 0.0.0.0 --port 8000
     ports:
       - ${PORT}:8000

--- a/server/src/Dockerfile
+++ b/server/src/Dockerfile
@@ -6,9 +6,10 @@ WORKDIR /usr/src/app
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/server/src"
 
 # copy requirements file
-COPY ./requirements.txt /usr/src/app/requirements.txt
+COPY ./server/src/requirements.txt /usr/src/app/requirements.txt
 
 # install dependencies
 RUN set -eux \


### PR DESCRIPTION
This small PR aims at allowing webser to access pyroengine 

Plus, the restart option has been added in order to handle webserver reboot.

I have some issues with pyroengine dependencies (will be fixed in another PR) so `server/src/requirements.txt` has not be updated. 

Feedback are welcome !