### PR TITLE
Solve vision dependencies compliance - alpine to slim docker image 

### DIFF
--- a/server/src/Dockerfile
+++ b/server/src/Dockerfile
@@ -19,9 +19,9 @@ ENV PATH /usr/local/bin:$PATH
 ENV LANG C.UTF-8
 
 # runtime dependencies
-RUN set -eux; \
-	apt-get update; \
-	apt-get install -y --no-install-recommends \
+RUN set -eux \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends \
 		ca-certificates \
 		netbase \
 	&& rm -rf /var/lib/apt/lists/*
@@ -30,9 +30,11 @@ ENV GPG_KEY 3.8.1
 ENV PYTHON_VERSION 3.8.1
 
 RUN set -ex \
+	 \
 	&& savedAptMark="$(apt-mark showmanual)" \
 	&& apt-get update && apt-get install -y --no-install-recommends \
 		gcc \
+		python3-dev \
 		libffi-dev \
 		libssl-dev \
 	&& pip install --upgrade pip setuptools wheel \

--- a/server/src/Dockerfile
+++ b/server/src/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.1-alpine
+FROM python:3.8.1-slim
 
 # set work directory
 WORKDIR /usr/src/app
@@ -11,11 +11,31 @@ ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app/server/src"
 # copy requirements file
 COPY ./server/src/requirements.txt /usr/src/app/requirements.txt
 
-# install dependencies
-RUN set -eux \
-    && apk add --no-cache --virtual .build-deps build-base \
-        libressl-dev libffi-dev gcc musl-dev python3-dev \
-    && pip install --upgrade pip setuptools wheel \
+# ensure local python is preferred over distribution python
+ENV PATH /usr/local/bin:$PATH
+
+# http://bugs.python.org/issue19846
+# > At the moment, setting "LANG=C" on a Linux system *fundamentally breaks Python 3*, and that's not OK.
+ENV LANG C.UTF-8
+
+# runtime dependencies
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		ca-certificates \
+		netbase \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GPG_KEY 3.8.1
+ENV PYTHON_VERSION 3.8.1
+
+RUN set -ex \
+	&& savedAptMark="$(apt-mark showmanual)" \
+	&& apt-get update && apt-get install -y --no-install-recommends \
+		gcc \
+		libffi-dev \
+		libssl-dev \
+	&& pip install --upgrade pip setuptools wheel \
     && pip install -r /usr/src/app/requirements.txt \
     && rm -rf /root/.cache/pip
 

--- a/server/src/requirements.txt
+++ b/server/src/requirements.txt
@@ -1,3 +1,5 @@
+opencv-python>=3.4.5.20
 fastapi==0.61.1
 uvicorn==0.11.1
 python-multipart==0.0.5
+pyroclient

--- a/server/src/requirements.txt
+++ b/server/src/requirements.txt
@@ -1,6 +1,6 @@
 fastapi==0.61.1
 uvicorn==0.11.1
 python-multipart==0.0.5
-pyrovision >= 0.1.2
-python-dotenv >= 0.15.0
-pyroclient
+pyrovision == 0.1.2
+python-dotenv == 0.17.0
+pyroclient == 0.1.1

--- a/server/src/requirements.txt
+++ b/server/src/requirements.txt
@@ -1,5 +1,6 @@
-opencv-python>=3.4.5.20
 fastapi==0.61.1
 uvicorn==0.11.1
 python-multipart==0.0.5
+pyrovision >= 0.1.2
+python-dotenv >= 0.15.0
 pyroclient


### PR DESCRIPTION
This PR aims at successfully building the webserver with pyro-vision dependencies. 

Some builds of pyro-vision requirements seems to not be available for alpine docker image ([open-cv]( https://stackoverflow.com/questions/50950588/trouble-installing-opencv-in-docker-container-using-pip), torch), and I cannot succeed to build the image with `pyro-vision` in requirements. 

Hence, this PR provides a **Dockerfile based on slim image** that allow webserver to be built with pyro-vision package

Btw : Some [resources](https://pythonspeed.com/articles/base-image-python-docker-images/) states that python could be faster on slim image than on alpine, that is a good point too. 

As long I am not so much knowledgeable, maybe some commands in the dockerfile could be removed to lighten the image. (https://github.com/docker-library/python/blob/master/Dockerfile-slim.template)


So far, with this set up, it is working. I am not so confident that it will work on pi with ARM processor, but this point should addressed in another issue/PR.

Feedbacks are welcome !
