### PR TITLE
Add network in docker-compose to allow for use under OpenVPN

### DIFF
--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -10,3 +10,10 @@ services:
     restart: always
     ports:
       - ${PORT}:8002
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.57.0/24


### PR DESCRIPTION
Hi everyone ! 

Small PR to fix an issue that occurs once the main rpi is under the VPN (provided by OpenVPN) and we have to launch the Docker build: it does not. The error is the following `ERROR: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network`.

According to [this](https://stackoverflow.com/questions/43720339/docker-error-could-not-find-an-available-non-overlapping-ipv4-address-pool-am) and since the main rpi is under OpenVPN, and especially the answer of people having such trouble with OpenVPN, the idea of the fix is to « specify what exactly subnet you want to use.» and this implies to add a « network » section in the `docker-compose.yml`:

```
networks:
  default:
    driver: bridge
    ipam:
      config:
        - subnet: 172.16.57.0/24
```

This means that the default network will be used and if the VPN did not assign you something from 172.16.57.* subnet, we are fine. 

With this the docker build is starting on RPI (great !). And ofc after some steps it fails cf issue #32 (error `standard_init_linux.go:219: exec user process caused: exec format error`). With this new version, the docker build works on local machine also (see screenshot from my computer) since the range of selected IPs is available on my network (it should be available on yours also by default, except if you chose on purpose to put something there before).

![Capture d’écran 2021-04-23 à 22 58 12](https://user-images.githubusercontent.com/57073096/115929120-87c05080-a487-11eb-8b72-8facebcb7de0.png)