### PR TITLE
Rewrite of runner.py to make it similar to monitor_pi.py

### DIFF
--- a/pyroengine/pi_utils/runner.py
+++ b/pyroengine/pi_utils/runner.py
@@ -3,13 +3,14 @@
 # This program is licensed under the GNU Affero General Public License version 3.
 # See LICENSE or go to <https://www.gnu.org/licenses/agpl-3.0.txt> for full license details.
 
-
+import logging
 import io
 import os
 import time
 import picamera
 import requests
 from dotenv import load_dotenv
+from requests import RequestException
 
 load_dotenv()
 
@@ -17,20 +18,49 @@ WEBSERVER_IP = os.environ.get("WEBSERVER_IP")
 WEBSERVER_PORT = os.environ.get("WEBSERVER_PORT")
 
 
-url = f"http://{WEBSERVER_IP}:{WEBSERVER_PORT}/inference/file"
+class Runner:
+    """This class aims at taking picture using PiCamera and sending the stream to local webserver in main raspberry"""
 
-stream = io.BytesIO()
-with picamera.PiCamera() as camera:
-    camera.resolution = (3280, 2464)  # use maximal resolution
-    while True:
-        print("capture")
+    logger = logging.getLogger(__name__)
+    CAPTURE_DELAY = 3
+    LOOP_INTERVAL = 3
+
+    def __init__(self, webserver_url):
+        """Initialize parameters for Runner."""
+        self.camera = picamera.PiCamera()
+        self.camera.resolution = (3280, 2464)  # use maximal resolution
+        self.webserver_url = webserver_url
+        self.is_running = True
+
+    def capture_stream(self):
         stream = io.BytesIO()
-        camera.start_preview()
-        time.sleep(3)  # small sleep here improve image quality
-        camera.capture(stream, format="jpeg")
+        self.camera.start_preview()
+        time.sleep(self.CAPTURE_DELAY)  # small sleep here improve image quality
+        self.camera.capture(stream, format="jpeg")
         # "Rewind" the stream to the beginning so we can read its content
         stream.seek(0)
-        files = {"file": stream}
-        requests.post(url, files=files)  # send image to pi_cental
+        return {"file": stream}
 
-        time.sleep(3)  # Wait between two capture
+    def send_stream(self, files):
+        try:
+            response = requests.post(
+                self.webserver_url, files=files
+            )  # send image to local webserver
+            response.raise_for_status()
+        except RequestException as e:
+            self.logger.error(f"Unexpected error in get_record(): {e!r}")
+
+    def run(self):
+        while self.is_running:
+            files = self.capture_stream()
+            self.send_stream(files)
+            time.sleep(self.LOOP_INTERVAL)  # Wait between two captures
+
+    def stop_runner(self):
+        self.is_running = False
+
+
+if __name__ == "__main__":
+    webserver_local_url = f"http://{WEBSERVER_IP}:{WEBSERVER_PORT}/inference/file"
+    runner = Runner(webserver_local_url)
+    runner.run()

--- a/test/fake_picamera.py
+++ b/test/fake_picamera.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2021, Pyronear contributors.
+
+# This program is licensed under the GNU Affero General Public License version 3.
+# See LICENSE or go to <https://www.gnu.org/licenses/agpl-3.0.txt> for full license details.
+
+
+class PiCamera:
+
+    @property
+    def resolution(self):
+        pass
+
+    @resolution.setter
+    def resolution(self, resolution):
+        pass
+
+    def start_preview(self):
+        pass
+
+    def capture(self, output, format=None):
+        pass

--- a/test/pi_patch.py
+++ b/test/pi_patch.py
@@ -5,6 +5,8 @@
 
 import sys
 import fake_gpiozero
+import fake_picamera
 
 
 sys.modules['gpiozero'] = fake_gpiozero
+sys.modules['picamera'] = fake_picamera

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) Pyronear contributors.
+# This file is dual licensed under the terms of the CeCILL-2.1 and AGPLv3 licenses.
+# See the LICENSE file in the root of this repository for complete details.
+import io
+import unittest
+from threading import Thread
+from unittest.mock import Mock, patch
+
+# noinspection PyUnresolvedReferences
+import pi_patch
+import requests
+from requests import RequestException
+
+from pyroengine.pi_utils.runner import Runner
+
+
+class RunnerTester(unittest.TestCase):
+    def setUp(self):
+        self.module_path = "pyroengine.pi_utils.runner"
+        Runner.CAPTURE_DELAY = 0
+        Runner.LOOP_INTERVAL = 0
+
+    def test_capture_stream(self):
+        with patch(f"{self.module_path}.picamera") as mock_picamera:
+            runner = Runner("my_url")
+            result = runner.capture_stream()
+
+        mock_picamera.PiCamera.assert_called_once_with()
+        mock_picamera.PiCamera.return_value.start_preview.assert_called_once_with()
+        mock_picamera.PiCamera.return_value.capture.assert_called_once_with(
+            result["file"], format="jpeg"
+        )
+
+    def test_send_stream_raises_request_exception_on_400(self):
+        with patch(f"{self.module_path}.requests") as mock_requests:
+            mock_response = Mock(spec=requests.Response)
+            mock_requests.post.return_value = mock_response
+            mock_response.raise_for_status.side_effect = RequestException()
+
+            runner = Runner("my_url")
+
+            files = {"file": io.BytesIO()}
+
+            runner.send_stream(files)
+
+            mock_response.raise_for_status.assert_called_once_with()
+
+    def test_run(self):
+        runner = Runner("my_url")
+        calls = []
+
+        def new_capture_stream():
+            calls.append(True)
+            if len(calls) == 3:
+                runner.stop_runner()
+
+        mock_capture_stream = Mock(side_effect=new_capture_stream)
+        with patch.object(runner, "capture_stream", new=mock_capture_stream):
+            runner.run()
+
+        self.assertEqual(3, mock_capture_stream.call_count)
+
+    def test_stop_runner(self):
+        runner = Runner("my_url")
+        monitoring_thread = Thread(target=lambda: runner.run(), daemon=True)
+        with patch(f"{self.module_path}.requests") as mock_requests:
+            mock_response = requests.Response()
+            mock_response.status_code = 200
+            mock_requests.post.return_value = mock_response
+
+            monitoring_thread.start()
+
+            runner.stop_runner()
+            monitoring_thread.join(timeout=1)
+            self.assertFalse(monitoring_thread.is_alive())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hi everyone ! 

I have taken the liberty of rewriting `runner.py` so that it matches the structure of `monitor_pi.py`, namely:
- create a class
- add logger (because I think that in the future it might be nice to catch the errors if some happens corresponding to RequestException, but for that I shall create rotating logs first, but anyways, not a priority)
- add corresponding unit tests

I proposed this new structure, any feedback is welcomed ! 🤗 

However I have a question regarding the code that was already in `runner.py`. \
The instantiation `stream = io.BytesIO()` was done two times: one before the loop (line 22) and one in the loop (line 27). Why is that ? \
The one in the loop overtakes the previous one. I'm not familiar with `io.Bytes`: do we need to re-instantiate it everytime we want to capture a stream ? I have supposed that it is the case in the code that I propose here. However if it's not, then we could move `stream = io.BytesIO()` in the `__init__` I guess. What do you think ? 

Also disclaimer: I could not test the entire code on my rpi since the dockerfile is not working, the `send_stream` method has thus not been tested, only the `capture_stream` and `run` ones have been. 

![Capture d’écran 2021-04-26 à 22 43 26](https://user-images.githubusercontent.com/57073096/116148161-d87eb600-a6e0-11eb-9d52-8957c2bdfdd1.png)