### PR TITLE
Take picture in pi camera, send and write in pi main

### DIFF
--- a/pyroengine/pi_utils/runner.py
+++ b/pyroengine/pi_utils/runner.py
@@ -2,6 +2,7 @@
 
 # This program is licensed under the GNU Affero General Public License version 3.
 # See LICENSE or go to <https://www.gnu.org/licenses/agpl-3.0.txt> for full license details.
+
 import argparse
 import logging
 import io
@@ -41,10 +42,10 @@ class Runner:
         stream.seek(0)
         return {"file": stream}
 
-    def send_stream(self, files, **kwargs):
+    def send_stream(self, files):
         try:
             response = requests.post(
-                self.webserver_url, files=files, **kwargs
+                self.webserver_url, files=files
             )  # send image to local webserver
             response.raise_for_status()
         except RequestException as e:
@@ -63,12 +64,14 @@ class Runner:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Take picture(s) and send to local web server')
     parser.add_argument('--single', action='store_true', help='Single picture instead of eternal loop')
+    parser.add_argument('--write', action='store_true', help='Use /write_image route instead of /inference')
     args = parser.parse_args()
 
-    webserver_local_url = f"http://{WEBSERVER_IP}:{WEBSERVER_PORT}/inference/file"
+    webserver_local_url = f"http://{WEBSERVER_IP}:{WEBSERVER_PORT}" + \
+                          ("/inference/file" if not args.write else "/write_image/file")
     runner = Runner(webserver_local_url)
     if args.single:
         files = runner.capture_stream()
-        runner.send_stream(files, action='write')
+        runner.send_stream(files)
     else:
         runner.run()

--- a/server/src/app/api/routes/inference.py
+++ b/server/src/app/api/routes/inference.py
@@ -24,13 +24,26 @@ def predict_and_alert(file):
     engine.predict(image)
 
 
+def write_picture(file):
+    """
+    Write picture to local storage. File name could include device name (see #37) and date.
+    Path could be retrieved from environment variable
+    """
+    pass  # FIXME
+
+
 @router.post("/file/", status_code=201, summary="Send img from a device to predict smoke")
 async def inference(background_tasks: BackgroundTasks,
-                    file: UploadFile = File(...)
+                    file: UploadFile = File(...),
+                    action: Optional[str] = 'infer',
                     ):
     """
     Get image from pizero and call engine for wildfire detection
     """
 
     # Call engine as background task
-    background_tasks.add_task(predict_and_alert, await file.read())
+    try:
+        fcn = {'infer': predict_and_alert, 'write': write_picture}[action]
+    except KeyError:
+        raise KeyError(f'Invalid action for route: {action}')
+    background_tasks.add_task(fcn, await file.read())

--- a/server/src/app/api/routes/inference.py
+++ b/server/src/app/api/routes/inference.py
@@ -24,26 +24,13 @@ def predict_and_alert(file):
     engine.predict(image)
 
 
-def write_picture(file):
-    """
-    Write picture to local storage. File name could include device name (see #37) and date.
-    Path could be retrieved from environment variable
-    """
-    pass  # FIXME
-
-
 @router.post("/file/", status_code=201, summary="Send img from a device to predict smoke")
 async def inference(background_tasks: BackgroundTasks,
-                    file: UploadFile = File(...),
-                    action: Optional[str] = 'infer',
+                    file: UploadFile = File(...)
                     ):
     """
     Get image from pizero and call engine for wildfire detection
     """
 
     # Call engine as background task
-    try:
-        fcn = {'infer': predict_and_alert, 'write': write_picture}[action]
-    except KeyError:
-        raise KeyError(f'Invalid action for route: {action}')
-    background_tasks.add_task(fcn, await file.read())
+    background_tasks.add_task(predict_and_alert, await file.read())

--- a/server/src/app/api/routes/write_image.py
+++ b/server/src/app/api/routes/write_image.py
@@ -20,20 +20,20 @@ engine = PyronearEngine()  # need to add api setup parameters here
 
 
 def write_image(file):
-    """Write image to $IMAGE_FOLDER (or /tmp) as image_YYYY-MM-DD_hh_mm_ss.jpg"""
+    """Write image to $IMAGE_FOLDER (or /tmp) as image_YYYY-MM-DD_hh_mm_ss.jpg."""
     image = Image.open(io.BytesIO(file))  # Load Image
+    output_dir = Path(os.getenv('IMAGE_FOLDER', Path.home() / 'images'))
+    output_dir.mkdir(parents=True, exist_ok=True)
     now = datetime.now().strftime('%Y-%m-%d_%H_%M_%S')
     # FIXME: add device to filename when it becomes available
-    fname = Path(os.getenv('IMAGE_FOLDER', '/tmp/')) / f'{now}.jpg'
-    image.save(fname)
+    fname = f'{now}.jpg'
+    image.save(output_dir / fname)
 
 
 @router.post("/file/", status_code=201, summary="Write image from a device")
 async def inference(background_tasks: BackgroundTasks,
                     file: UploadFile = File(...)
                     ):
-    """
-    Get image from pizero and write it to $IMAGE_FOLDER
-    """
+    """Get image from pizero and write it to $IMAGE_FOLDER"""
     # Call write_image as background task
     background_tasks.add_task(write_image, await file.read())

--- a/server/src/app/api/routes/write_image.py
+++ b/server/src/app/api/routes/write_image.py
@@ -34,6 +34,6 @@ def write_image(file):
 async def inference(background_tasks: BackgroundTasks,
                     file: UploadFile = File(...)
                     ):
-    """Get image from pizero and write it to $IMAGE_FOLDER"""
+    """Get image from pizero and write it to $IMAGE_FOLDER."""
     # Call write_image as background task
     background_tasks.add_task(write_image, await file.read())

--- a/server/src/app/api/routes/write_image.py
+++ b/server/src/app/api/routes/write_image.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2021, Pyronear contributors.
+
+# This program is licensed under the GNU Affero General Public License version 3.
+# See LICENSE or go to <https://www.gnu.org/licenses/agpl-3.0.txt> for full license details.
+
+
+import os
+import io
+from pathlib import Path
+from datetime import datetime
+
+from fastapi import APIRouter, BackgroundTasks
+from fastapi import File, UploadFile
+from pyroengine.engine import PyronearEngine
+from PIL import Image
+
+
+router = APIRouter()
+engine = PyronearEngine()  # need to add api setup parameters here
+
+
+def write_image(file):
+    """Write image to $IMAGE_FOLDER (or /tmp) as image_YYYY-MM-DD_hh_mm_ss.jpg"""
+    image = Image.open(io.BytesIO(file))  # Load Image
+    now = datetime.now().strftime('%Y-%m-%d_%H_%M_%S')
+    # FIXME: add device to filename when it becomes available
+    fname = Path(os.getenv('IMAGE_FOLDER', '/tmp/')) / f'{now}.jpg'
+    image.save(fname)
+
+
+@router.post("/file/", status_code=201, summary="Write image from a device")
+async def inference(background_tasks: BackgroundTasks,
+                    file: UploadFile = File(...)
+                    ):
+    """
+    Get image from pizero and write it to $IMAGE_FOLDER
+    """
+    # Call write_image as background task
+    background_tasks.add_task(write_image, await file.read())

--- a/server/src/app/main.py
+++ b/server/src/app/main.py
@@ -17,7 +17,7 @@ app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, versi
 # Routing
 app.include_router(metrics.router, prefix="/metrics", tags=['metrics'])
 app.include_router(inference.router, prefix="/inference", tags=['inference'])
-app.include_router(write.router, prefix="/write_image", tags=['write'])
+app.include_router(write_image.router, prefix="/write_image", tags=['write'])
 
 
 # Middleware

--- a/server/src/app/main.py
+++ b/server/src/app/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, Request
 from fastapi.openapi.utils import get_openapi
 
 from app import config as cfg
-from app.api.routes import metrics, inference
+from app.api.routes import metrics, inference, write_image
 
 app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, version=cfg.VERSION)
 
@@ -17,6 +17,7 @@ app = FastAPI(title=cfg.PROJECT_NAME, description=cfg.PROJECT_DESCRIPTION, versi
 # Routing
 app.include_router(metrics.router, prefix="/metrics", tags=['metrics'])
 app.include_router(inference.router, prefix="/inference", tags=['inference'])
+app.include_router(write.router, prefix="/write_image", tags=['write'])
 
 
 # Middleware

--- a/server/src/tests/routes/test_write_image.py
+++ b/server/src/tests/routes/test_write_image.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2021, Pyronear contributors.
+
+# This program is licensed under the GNU Affero General Public License version 3.
+# See LICENSE or go to <https://www.gnu.org/licenses/agpl-3.0.txt> for full license details.
+
+
+import requests
+
+
+def test_write_image(test_app):
+
+    img_content = requests.get("https://pyronear.org/img/logo_letters.png").content
+
+    response = test_app.post("/write_image/", files=dict(file=img_content))
+
+    assert response.status_code == 201


### PR DESCRIPTION
This PR aims at adding a way to take a single picture in a pi camera, send it to a main RPI and write it locally. This will simplify the hardware installation process and possibly future checks.

This is just a draft code / minimal example to initiate the discussion, no checks and tests added. If this is included, the next step could be to have an interface to request pictures from specific pi camera devices and view the latest ones in the local pi main web server.
