### PR TITLE
Add bash script for internet failures scenario

### DIFF
--- a/pyroengine/pi_utils/check_internet_connection.sh
+++ b/pyroengine/pi_utils/check_internet_connection.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# This script performs:
+# Ping google.com:
+#	- if success:
+#		Ping internal vpn ip:
+#		- if success: ok exit
+#		- if failure: restart vpn
+#
+#	- if failure: restart of network interfaces
+# Sleep 60 sec
+# Ping google again (to make sure that we have internet):
+#	- if success: ok exit
+#	- if failure: reboot
+
+set -u
+
+PING_CMD=('ping' '-c' '1' '-W' '10' 'google.com')
+
+if "${PING_CMD[@]}";
+then
+    iplocalhostvpn=$(ifconfig tun0 | awk '/inet / {print $2}')
+    PING_CMD_VPN=('ping' '-c' '1' '-W' '10' "$iplocalhostvpn")
+    if "${PING_CMD_VPN[@]}";
+    then
+          exit 0;
+    fi;
+
+    sudo systemctl restart openvpn@client;
+fi;
+
+sudo service networking restart;
+sleep 60;
+
+if "${PING_CMD[@]}";
+then
+    exit 0;
+fi;
+
+sudo reboot;


### PR DESCRIPTION
Hi everyone, 

In this PR you can find a proposition for internet failures scenario. This script bash will then be added on the main rpi (using pyro-sys-setup) and will be put in a cron job so that in it run every 15 minutes for instance (the number here is chosen arbitrarily, if you have better ideas, feel free to tell me).

The flow is the following:
```
Ping internet: 
	- if success: 
		Ping vpn:
		- if success: ok exit 
		- if failure: restart vpn

	- if failure: restart of network interfaces (all interfaces because I don't know which internet the 4G modem will take)
sleep 60 sec
Ping internet again (to make sure that we have internet):
	- if success: ok exit
	- if failure: reboot
```

What do you think ? 