### PR TITLE
Improved router reboot script

### DIFF
--- a/pyroengine/pi_utils/check_internet_connection.sh
+++ b/pyroengine/pi_utils/check_internet_connection.sh
@@ -36,4 +36,7 @@ then
     exit 0;
 fi;
 
+python3 /home/pi/pyro-engine/pyroengine/pi_utils/reboot_router;
+sleep 60;
+
 sudo reboot;


### PR DESCRIPTION
This script to solve connection problems does not restart the rooter. We saw that the majority of the connection problems come from the rooter it is therefore essential to restart it in case of connection loss