### PR TITLE
add monitor runner

### DIFF
--- a/pyroengine/pi_utils/pi_zeros/monitor_runner.sh
+++ b/pyroengine/pi_utils/pi_zeros/monitor_runner.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+until python3 /home/pi/pi_zeros/runner.py; do
+    echo "'runner.py' crashed with exit code $?. Restarting..." >&2
+    sleep 1
+done


### PR DESCRIPTION
The aim of this PR is to replace the PR #69, this solution allows thanks to a bash script to keep the runner alive.

This script must be added to the crontab to be launched at reboot time

@reboot bash /home/pi/pi_zeros/monitor_runner.sh