### PR TITLE
test: Added unittests with Alert API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,8 @@ jobs:
       - name: Run unittests
         env:
           API_URL: ${{ secrets.API_URL }}
+          API_LOGIN: ${{ secrets.API_LOGIN }}
+          API_PWD: ${{ secrets.API_PWD }}
           LAT: 48.88
           LON: 2.38
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[test]" --upgrade
       - name: Run unittests
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          LAT: 48.88
+          LON: 2.38
         run: |
           coverage run -m pytest tests/
           coverage xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ test = [
     "pytest>=5.3.2",
     "coverage[toml]>=4.5.4",
     "requests>=2.20.0,<3.0.0",
+    "python-dotenv>=0.15.0",
 ]
 quality = [
     "flake8>=3.9.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,11 @@ from PIL import Image
 
 
 @pytest.fixture(scope="session")
-def mock_classification_image(tmpdir_factory):
+def mock_image_stream(tmpdir_factory):
     url = "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/fire_sample_image.jpg"
-    return Image.open(BytesIO(requests.get(url).content))
+    return requests.get(url).content
+
+
+@pytest.fixture(scope="session")
+def mock_image_content(tmpdir_factory, mock_image_stream):
+    return Image.open(BytesIO(mock_image_stream))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,22 @@ from PIL import Image
 
 
 @pytest.fixture(scope="session")
-def mock_image_stream(tmpdir_factory):
+def mock_wildfire_stream(tmpdir_factory):
     url = "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/fire_sample_image.jpg"
     return requests.get(url).content
 
 
 @pytest.fixture(scope="session")
-def mock_image_content(tmpdir_factory, mock_image_stream):
-    return Image.open(BytesIO(mock_image_stream))
+def mock_wildfire_image(tmpdir_factory, mock_wildfire_stream):
+    return Image.open(BytesIO(mock_wildfire_stream))
+
+
+@pytest.fixture(scope="session")
+def mock_forest_stream(tmpdir_factory):
+    url = "https://github.com/pyronear/pyro-engine/releases/download/v0.1.1/forest_sample.jpg"
+    return requests.get(url).content
+
+
+@pytest.fixture(scope="session")
+def mock_forest_image(tmpdir_factory, mock_forest_stream):
+    return Image.open(BytesIO(mock_forest_stream))

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -1,20 +1,23 @@
 import json
+import os
 from datetime import datetime
+from pathlib import Path
+
+from dotenv import load_dotenv
 
 from pyroengine.core import Engine
 
 
-def test_engine(tmpdir_factory, mock_classification_image):
+def test_engine_offline(tmpdir_factory, mock_image_stream, mock_image_content):
 
     # Cache
     folder = str(tmpdir_factory.mktemp("engine_cache"))
 
-    # No API
     engine = Engine("pyronear/rexnet1_3x", cache_folder=folder)
 
     # Cache saving
     _ts = datetime.utcnow().isoformat()
-    engine._stage_alert(mock_classification_image, 0)
+    engine._stage_alert(mock_image_content, 0)
     assert len(engine._alerts) == 1
     assert engine._alerts[0]["ts"] < datetime.utcnow().isoformat() and _ts < engine._alerts[0]["ts"]
     assert engine._alerts[0]["media_id"] is None
@@ -38,13 +41,58 @@ def test_engine(tmpdir_factory, mock_classification_image):
     engine.clear_cache()
 
     # inference
-    engine = Engine("pyronear/rexnet1_3x", cache_folder=folder)
-    out = engine.predict(mock_classification_image, 0)
+    engine = Engine("pyronear/rexnet1_3x", alert_relaxation=3, cache_folder=folder)
+    out = engine.predict(mock_image_content)
     assert isinstance(out, float) and 0 <= out <= 1
     # Alert relaxation
     assert not engine._states["-1"]["ongoing"]
-    out = engine.predict(mock_classification_image, 0)
-    out = engine.predict(mock_classification_image, 0)
+    out = engine.predict(mock_image_content)
+    out = engine.predict(mock_image_content)
     assert engine._states["-1"]["ongoing"]
 
+
+def test_engine_online(tmpdir_factory, mock_image_stream, mock_image_content):
+    # Cache
+    folder = str(tmpdir_factory.mktemp("engine_cache"))
     # With API
+    load_dotenv(Path(__file__).parent.parent.joinpath(".env").absolute())
+    api_url = os.environ.get("API_URL")
+    lat = os.environ.get("LAT")
+    lon = os.environ.get("LON")
+    cam_creds = {"dummy_cam": {"login": os.environ.get("API_LOGIN"), "password": os.environ.get("API_PWD")}}
+    # Skip the API-related tests if the URL is not specified
+    if isinstance(api_url, str):
+        engine = Engine(
+            "pyronear/rexnet1_3x",
+            api_url=api_url,
+            cam_creds=cam_creds,
+            latitude=float(lat),
+            longitude=float(lon),
+            alert_relaxation=2,
+            frame_saving_period=3,
+            cache_folder=folder,
+            frame_size=(224, 224),
+        )
+        # Heartbeat
+        start_ts = datetime.utcnow().isoformat()
+        response = engine.heartbeat("dummy_cam")
+        assert response.status_code // 100 == 2
+        ts = datetime.utcnow().isoformat()
+        json_respone = response.json()
+        assert start_ts < json_respone["last_ping"] < ts
+        # Send an alert
+        engine.predict(mock_image_content, "dummy_cam")
+        assert len(engine._alerts) == 0 and engine._states["dummy_cam"]["consec"] == 1
+        assert engine._states["dummy_cam"]["frame_count"] == 1
+        engine.predict(mock_image_content, "dummy_cam")
+        assert engine._states["dummy_cam"]["consec"] == 2 and engine._states["dummy_cam"]["ongoing"]
+        assert engine._states["dummy_cam"]["frame_count"] == 2
+        # Check that a media and an alert have been registered
+        assert len(engine._alerts) == 0
+        # Upload a frame
+        response = engine._upload_frame("dummy_cam", mock_image_stream)
+        assert response.status_code // 100 == 2
+        # Upload frame in process
+        engine.predict(mock_image_content, "dummy_cam")
+        # Check that a new media has been created & uploaded
+        assert engine._states["dummy_cam"]["frame_count"] == 0

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -8,7 +8,7 @@ from dotenv import load_dotenv
 from pyroengine.core import Engine
 
 
-def test_engine_offline(tmpdir_factory, mock_image_stream, mock_image_content):
+def test_engine_offline(tmpdir_factory, mock_wildfire_image, mock_forest_image):
 
     # Cache
     folder = str(tmpdir_factory.mktemp("engine_cache"))
@@ -17,7 +17,7 @@ def test_engine_offline(tmpdir_factory, mock_image_stream, mock_image_content):
 
     # Cache saving
     _ts = datetime.utcnow().isoformat()
-    engine._stage_alert(mock_image_content, 0)
+    engine._stage_alert(mock_wildfire_image, 0)
     assert len(engine._alerts) == 1
     assert engine._alerts[0]["ts"] < datetime.utcnow().isoformat() and _ts < engine._alerts[0]["ts"]
     assert engine._alerts[0]["media_id"] is None
@@ -34,6 +34,8 @@ def test_engine_offline(tmpdir_factory, mock_image_stream, mock_image_content):
         "cam_id": 0,
         "ts": engine._alerts[0]["ts"],
     }
+    # Overrites cache files
+    engine._dump_cache()
 
     # Cache dump loading
     engine = Engine("pyronear/rexnet1_3x", cache_folder=folder)
@@ -42,16 +44,22 @@ def test_engine_offline(tmpdir_factory, mock_image_stream, mock_image_content):
 
     # inference
     engine = Engine("pyronear/rexnet1_3x", alert_relaxation=3, cache_folder=folder)
-    out = engine.predict(mock_image_content)
+    out = engine.predict(mock_forest_image)
     assert isinstance(out, float) and 0 <= out <= 1
+    assert engine._states["-1"]["consec"] == 0
+    out = engine.predict(mock_wildfire_image)
+    assert isinstance(out, float) and 0 <= out <= 1
+    assert engine._states["-1"]["consec"] == 1
     # Alert relaxation
     assert not engine._states["-1"]["ongoing"]
-    out = engine.predict(mock_image_content)
-    out = engine.predict(mock_image_content)
+    out = engine.predict(mock_wildfire_image)
+    assert engine._states["-1"]["consec"] == 2
+    out = engine.predict(mock_wildfire_image)
+    assert engine._states["-1"]["consec"] == 3
     assert engine._states["-1"]["ongoing"]
 
 
-def test_engine_online(tmpdir_factory, mock_image_stream, mock_image_content):
+def test_engine_online(tmpdir_factory, mock_wildfire_stream, mock_wildfire_image):
     # Cache
     folder = str(tmpdir_factory.mktemp("engine_cache"))
     # With API
@@ -81,18 +89,18 @@ def test_engine_online(tmpdir_factory, mock_image_stream, mock_image_content):
         json_respone = response.json()
         assert start_ts < json_respone["last_ping"] < ts
         # Send an alert
-        engine.predict(mock_image_content, "dummy_cam")
+        engine.predict(mock_wildfire_image, "dummy_cam")
         assert len(engine._alerts) == 0 and engine._states["dummy_cam"]["consec"] == 1
         assert engine._states["dummy_cam"]["frame_count"] == 1
-        engine.predict(mock_image_content, "dummy_cam")
+        engine.predict(mock_wildfire_image, "dummy_cam")
         assert engine._states["dummy_cam"]["consec"] == 2 and engine._states["dummy_cam"]["ongoing"]
         assert engine._states["dummy_cam"]["frame_count"] == 2
         # Check that a media and an alert have been registered
         assert len(engine._alerts) == 0
         # Upload a frame
-        response = engine._upload_frame("dummy_cam", mock_image_stream)
+        response = engine._upload_frame("dummy_cam", mock_wildfire_stream)
         assert response.status_code // 100 == 2
         # Upload frame in process
-        engine.predict(mock_image_content, "dummy_cam")
+        engine.predict(mock_wildfire_image, "dummy_cam")
         # Check that a new media has been created & uploaded
         assert engine._states["dummy_cam"]["frame_count"] == 0

--- a/tests/test_engine_vision.py
+++ b/tests/test_engine_vision.py
@@ -4,16 +4,16 @@ from huggingface_hub import hf_hub_download
 from pyroengine.vision import Classifier
 
 
-def test_classifier(mock_image_content):
+def test_classifier(mock_wildfire_image):
 
     # Instantiae the ONNX model
     model = Classifier("pyronear/rexnet1_3x")
     # Check preprocessing
-    out = model.preprocess_image(mock_image_content)
+    out = model.preprocess_image(mock_wildfire_image)
     assert isinstance(out, np.ndarray) and out.dtype == np.float32
     assert out.shape == (1, 3, 224, 224)
     # Check inference
-    out = model(mock_image_content)
+    out = model(mock_wildfire_image)
     assert isinstance(out, np.ndarray) and out.dtype == np.float32
     assert out.shape == (1,)
     assert out >= 0 and out <= 1

--- a/tests/test_engine_vision.py
+++ b/tests/test_engine_vision.py
@@ -4,16 +4,16 @@ from huggingface_hub import hf_hub_download
 from pyroengine.vision import Classifier
 
 
-def test_classifier(mock_classification_image):
+def test_classifier(mock_image_content):
 
     # Instantiae the ONNX model
     model = Classifier("pyronear/rexnet1_3x")
     # Check preprocessing
-    out = model.preprocess_image(mock_classification_image)
+    out = model.preprocess_image(mock_image_content)
     assert isinstance(out, np.ndarray) and out.dtype == np.float32
     assert out.shape == (1, 3, 224, 224)
     # Check inference
-    out = model(mock_classification_image)
+    out = model(mock_image_content)
     assert isinstance(out, np.ndarray) and out.dtype == np.float32
     assert out.shape == (1,)
     assert out >= 0 and out <= 1


### PR DESCRIPTION
This PR introduces the following modifications:
- updates test dependencies
- passes down .env from the CI
- adds unittests with the API
- improves logging in Engine
- renames `client_creds` into `cam_creds`
- fixes edge case for state update
- return HTTP response in private methods (for unittests)

Closes #51

Any feedback is welcome!