### PR TITLE
feat: Added log management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,8 @@ services:
     volumes:
       - ./data:/usr/src/app/data
     restart: always
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "5"


### PR DESCRIPTION

The size of the logs is not yet a problem, but on the one hand we have quite a lot of logs (especially in case of trouble), and on the other hand the current approach is to simply make the log file grow infinitely ♾️  !

Hence, in order to prevent possible future issues, we should manage log files rotation and remove oldest. 

Fortunately, this can be done in a few lines with [docker](https://docs.docker.com/config/containers/logging/json-file/). 

This PR introduces the following modifications : 
- Adds logging to docker compose (json-file logging driver, size max and 5 file max)

As long as there space available on devices, I've picked max-size as 100mo and 5 file maximum but open to discuss it :) 

Happy to discuss it 😄 

PS : log files are accessible at `/var/lib/docker/containers/the_relevant_container/`
