### PR TITLE
catch heartbeat error

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -194,7 +194,7 @@ class Engine:
         if len(self.api_client) > 0 and isinstance(cam_id, str):
             try:
                 self.heartbeat(cam_id)
-            except Exception:
+            except ConnectionError:
                 logging.warning(f"Unable to reach the pyro-api with {cam_id}")
 
         # Inference with ONNX

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -192,7 +192,10 @@ class Engine:
 
         # Heartbeat
         if len(self.api_client) > 0 and isinstance(cam_id, str):
-            self.heartbeat(cam_id)
+            try:
+                self.heartbeat(cam_id)
+            except Exception:
+                logging.warning(f"Unable to reach the pyro-api with {cam_id}")
 
         # Inference with ONNX
         pred = float(self.model(frame.convert("RGB")))


### PR DESCRIPTION
When internet is down, heartbeat raise an error witch is catch by this [try/catch](https://github.com/pyronear/pyro-engine/blob/b1533c55f05faa56717e56a26a4b7571bfc17703/pyroengine/core.py#L37) and lead to "Unable to analyze stream from camera xx" warning. If think it's better to add a heartbeat try/catch for clarity purpose 

