### PR TITLE
Make all params availables from run

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -15,8 +15,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
+from mockpyroclient import client
 from PIL import Image
-from pyroclient import client
 from requests.exceptions import ConnectionError
 from requests.models import Response
 
@@ -88,6 +88,7 @@ class Engine:
         cache_size: int = 100,
         cache_folder: str = "data/",
         backup_size: int = 30,
+        jpeg_quality: int = 80,
         **kwargs: Any,
     ) -> None:
         """Init engine"""
@@ -111,7 +112,7 @@ class Engine:
         self.frame_saving_period = frame_saving_period
         self.alert_relaxation = alert_relaxation
         self.frame_size = frame_size
-        self.jpeg_quality = 50
+        self.jpeg_quality = jpeg_quality
         self.cache_backup_period = cache_backup_period
 
         # Local backup

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -15,8 +15,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-from pyroclient import client
 from PIL import Image
+from pyroclient import client
 from requests.exceptions import ConnectionError
 from requests.models import Response
 

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-from mockpyroclient import client
+from pyroclient import client
 from PIL import Image
 from requests.exceptions import ConnectionError
 from requests.models import Response

--- a/src/run.py
+++ b/src/run.py
@@ -65,6 +65,10 @@ def main(args):
         cache_folder=args.cache,
         revision=args.revision,
         backup_size=args.backup_size,
+        alert_relaxation = args.alert_relaxation,
+        frame_size = args.frame_size,
+        cache_backup_period = args.cache_backup_period,
+        cache_size = args.cache_size,
     )
 
     sys_controller = SystemController(
@@ -92,6 +96,10 @@ if __name__ == "__main__":
     # Camera & cache
     parser.add_argument("--creds", type=str, default="data/credentials.json", help="Camera credentials")
     parser.add_argument("--cache", type=str, default="./data", help="Cache folder")
+    parser.add_argument("--frame-size", type=tuple, default=(1280, 720), help="Frame size to save")
+    parser.add_argument("--cache-size", type=int, default=20, help="Frame size to save")
+    parser.add_argument("--alert_relaxation", type=int, default=2, help="Frame size to save")
+    parser.add_argument("--cache_backup_period", type=int, default=60, help="Frame size to save")
     # Backup
     parser.add_argument("--backup-size", type=int, default=10000, help="Local backup can't be bigger than 10Go")
     # Time config

--- a/src/run.py
+++ b/src/run.py
@@ -65,10 +65,11 @@ def main(args):
         cache_folder=args.cache,
         revision=args.revision,
         backup_size=args.backup_size,
-        alert_relaxation = args.alert_relaxation,
-        frame_size = args.frame_size,
-        cache_backup_period = args.cache_backup_period,
-        cache_size = args.cache_size,
+        alert_relaxation=args.alert_relaxation,
+        frame_size=args.frame_size,
+        cache_backup_period=args.cache_backup_period,
+        cache_size=args.cache_size,
+        jpeg_quality=args.jpeg_quality,
     )
 
     sys_controller = SystemController(
@@ -96,10 +97,23 @@ if __name__ == "__main__":
     # Camera & cache
     parser.add_argument("--creds", type=str, default="data/credentials.json", help="Camera credentials")
     parser.add_argument("--cache", type=str, default="./data", help="Cache folder")
-    parser.add_argument("--frame-size", type=tuple, default=(1280, 720), help="Frame size to save")
-    parser.add_argument("--cache-size", type=int, default=20, help="Frame size to save")
-    parser.add_argument("--alert_relaxation", type=int, default=2, help="Frame size to save")
-    parser.add_argument("--cache_backup_period", type=int, default=60, help="Frame size to save")
+    parser.add_argument(
+        "--frame-size",
+        type=tuple,
+        default=(720, 1280),
+        help="Resize frame to frame_size before sending it to the api in order to save bandwidth (H, W)",
+    )
+    parser.add_argument("--jpeg_quality", type=int, default=80, help="Jpeg compression")
+    parser.add_argument("--cache-size", type=int, default=20, help="Maximum number of alerts to save in cache")
+    parser.add_argument(
+        "--alert_relaxation",
+        type=int,
+        default=1,
+        help="Number of consecutive positive detections required to send the first alert",
+    )
+    parser.add_argument(
+        "--cache_backup_period", type=int, default=60, help="Number of minutes between each cache backup to disk"
+    )
     # Backup
     parser.add_argument("--backup-size", type=int, default=10000, help="Local backup can't be bigger than 10Go")
     # Time config

--- a/src/run.py
+++ b/src/run.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--alert_relaxation",
         type=int,
-        default=1,
+        default=2,
         help="Number of consecutive positive detections required to send the first alert",
     )
     parser.add_argument(


### PR DESCRIPTION
The purpose of this pr is to make all engine parameters accessible from run so it is easier to test different configurations.

Also I changed some default values.

frame_size 4k > 720,1280 the 4k image is too heavy for some towers

jpeg_quality 50 > 80, the compression was too strong with some artifacts especially in low light

cache-size 100 > 20 to try not to saturate the ram

alert_relaxation 3 > 2 because the model is better now I propose to decrease the alert_relaxation

