### PR TITLE
analyze stream timeout

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -69,7 +69,7 @@ def main(args):
 
     while True:
         start_ts = time.time()
-        sys_controller.run()
+        sys_controller.run(args.period)
         # Sleep only once all images are processed
         time.sleep(max(args.period - time.time() + start_ts, 0))
 


### PR DESCRIPTION
We had a problem for several months now, the system is blocking and not analyzing any image while the docker is not stopped. We investigated with @fe51 these last days and we finally found the problem. It seems that some calls to the api don't have a timeout which makes the system wait forever.

While waiting for this problem to be fixed on the api side, I propose the following fix. I added a timeout on the call of the analyze stream function for each camera. The execution time of this function should not exceed period / number of cameras (in our case 30 /4 = 7.5 s).

Even if this code is a hotfix, it might make sense to keep it in the future. Even if the bug has been fixed on the api side