### PR TITLE
update docker img

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.1-slim
+FROM python:3.8.16-slim
 
 # set environment variables
 ENV PYTHONPATH "${PYTHONPATH}:/usr/src/app"


### PR DESCRIPTION
Our current docker image [python:3.8.1-slim](https://hub.docker.com/layers/library/python/3.8.1-slim/images/sha256-f4fa27e3c1004088eac76590b800f1efa813cc9baae827dee152895deba2fd28?context=explore) haven't been updated for 3 year now, let's use [python:3.8.16-slim](https://hub.docker.com/layers/library/python/3.8.16-slim/images/sha256-92689d355058ec11621b8ad082b5e9191143aac0019051aaff702ede49ed2502?context=explore) instead