### PR TITLE
Ir day night

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 from PIL import Image
+import numpy as np
 from pyroclient import client
 from requests.exceptions import ConnectionError
 from requests.models import Response
@@ -27,23 +28,37 @@ __all__ = ["Engine"]
 logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=logging.INFO, force=True)
 
 
-def is_day_time(cache, delta=0):
-    """Read sunset and sunrise hour in sunset_sunrise.txt and check if we are currently on daytime. We don't want to
-    trigger night alerts for now. We take delta s margin
+def is_day_time(cache, frame, strategy, delta=0):
+    """This function allows to know if it is daytime or not. We have two strategies. 
+    The first one is to take the current time and compare it to the sunset time. 
+    The second is to see if we have a color image. The ir cameras switch to ir at night and 
+    therefore produce black and white images. This function can use one or more strategies depending on the use case.
 
     Args:
         cache (Path): cache folder where sunset_sunrise.txt is located
+        frame (PIL image): frame to analyze with ir strategy
+        strategy (str): Strategy to define day time [None, time, ir or both]
         delta (int): delta before and after sunset / sunrise in sec
 
     Returns:
         bool: is day time
     """
-    with open(cache.joinpath("sunset_sunrise.txt")) as f:
-        lines = f.readlines()
-    sunrise = datetime.strptime(lines[0][:-1], "%H:%M")
-    sunset = datetime.strptime(lines[1][:-1], "%H:%M")
-    now = datetime.strptime(datetime.now().isoformat().split("T")[1][:5], "%H:%M")
-    return (now - sunrise).total_seconds() > -delta and (sunset - now).total_seconds() > -delta
+    is_day = True
+    if strategy in ["both", "time"]:
+        with open(cache.joinpath("sunset_sunrise.txt")) as f:
+            lines = f.readlines()
+        sunrise = datetime.strptime(lines[0][:-1], "%H:%M")
+        sunset = datetime.strptime(lines[1][:-1], "%H:%M")
+        now = datetime.strptime(datetime.now().isoformat().split("T")[1][:5], "%H:%M")
+        if (now - sunrise).total_seconds() < -delta or (sunset - now).total_seconds() < -delta:
+            is_day = False
+
+    if strategy in ["both", "ir"]:
+        frame = np.array(frame)
+        if np.max(frame[:,:,0] - frame[:,:,1]) == 0:
+            is_day = False
+
+    return is_day
 
 
 class Engine:
@@ -89,6 +104,7 @@ class Engine:
         cache_folder: str = "data/",
         backup_size: int = 30,
         jpeg_quality: int = 80,
+        day_time_strategy: str = None,
         **kwargs: Any,
     ) -> None:
         """Init engine"""
@@ -228,7 +244,7 @@ class Engine:
         if isinstance(self.frame_size, tuple):
             frame_resize = frame.resize(self.frame_size[::-1], Image.BILINEAR)
 
-        if is_day_time(self._cache):
+        if is_day_time(self._cache, frame, day_time_strategy):
             # Inference with ONNX
             pred = float(self.model(frame.convert("RGB")))
             # Log analysis result

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -27,9 +27,9 @@ __all__ = ["Engine"]
 logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=logging.INFO, force=True)
 
 
-def is_day_time(cache, delta=3600, utc=2):
+def is_day_time(cache, delta=0, utc=2):
     """Read sunset and sunrise hour in sunset_sunrise.txt and check if we are currently on daytime. We don't want to
-    trigger night alerts for now. We take 1 hour margin
+    trigger night alerts for now. We take delta s margin
 
     Args:
         cache (Path): cache folder where sunset_sunrise.txt is located

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -27,14 +27,13 @@ __all__ = ["Engine"]
 logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=logging.INFO, force=True)
 
 
-def is_day_time(cache, delta=0, utc=2):
+def is_day_time(cache, delta=0):
     """Read sunset and sunrise hour in sunset_sunrise.txt and check if we are currently on daytime. We don't want to
     trigger night alerts for now. We take delta s margin
 
     Args:
         cache (Path): cache folder where sunset_sunrise.txt is located
         delta (int): delta before and after sunset / sunrise in sec
-        utc (int): coordinated Universal Time of the current station
 
     Returns:
         bool: is day time
@@ -44,7 +43,6 @@ def is_day_time(cache, delta=0, utc=2):
     sunrise = datetime.strptime(lines[0][:-1], "%H:%M")
     sunset = datetime.strptime(lines[1][:-1], "%H:%M")
     now = datetime.strptime(datetime.now().isoformat().split("T")[1][:5], "%H:%M")
-    now = now - timedelta(hours=utc)  # convert to utc 0
     return (now - sunrise).total_seconds() > -delta and (sunset - now).total_seconds() > -delta
 
 

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -31,7 +31,7 @@ logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=log
 def is_day_time(cache, frame, strategy, delta=0):
     """This function allows to know if it is daytime or not. We have two strategies. 
     The first one is to take the current time and compare it to the sunset time. 
-    The second is to see if we have a color image. The ir cameras switch to ir at night and 
+    The second is to see if we have a color image. The ir cameras switch to ir mode at night and 
     therefore produce black and white images. This function can use one or more strategies depending on the use case.
 
     Args:

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -15,8 +15,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
-from PIL import Image
 import numpy as np
+from PIL import Image
 from pyroclient import client
 from requests.exceptions import ConnectionError
 from requests.models import Response
@@ -29,9 +29,9 @@ logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=log
 
 
 def is_day_time(cache, frame, strategy, delta=0):
-    """This function allows to know if it is daytime or not. We have two strategies. 
-    The first one is to take the current time and compare it to the sunset time. 
-    The second is to see if we have a color image. The ir cameras switch to ir mode at night and 
+    """This function allows to know if it is daytime or not. We have two strategies.
+    The first one is to take the current time and compare it to the sunset time.
+    The second is to see if we have a color image. The ir cameras switch to ir mode at night and
     therefore produce black and white images. This function can use one or more strategies depending on the use case.
 
     Args:
@@ -55,7 +55,7 @@ def is_day_time(cache, frame, strategy, delta=0):
 
     if strategy in ["both", "ir"]:
         frame = np.array(frame)
-        if np.max(frame[:,:,0] - frame[:,:,1]) == 0:
+        if np.max(frame[:, :, 0] - frame[:, :, 1]) == 0:
             is_day = False
 
     return is_day
@@ -77,6 +77,7 @@ class Engine:
         cache_backup_period: number of minutes between each cache backup to disk
         frame_saving_period: Send one frame over N to the api for our dataset
         cache_size: maximum number of alerts to save in cache
+        day_time_strategy: strategy to define if it's daytime
         kwargs: keyword args of Classifier
 
     Examples:

--- a/src/run.py
+++ b/src/run.py
@@ -60,6 +60,7 @@ def main(args):
         cache_backup_period=args.cache_backup_period,
         cache_size=args.cache_size,
         jpeg_quality=args.jpeg_quality,
+        day_time_strategy=args.day_time_strategy,
     )
 
     sys_controller = SystemController(
@@ -101,6 +102,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--cache_backup_period", type=int, default=60, help="Number of minutes between each cache backup to disk"
     )
+    parser.add_argument("--day_time_strategy", type=str, default="ir", help="strategy to define if it's daytime")
     # Backup
     parser.add_argument("--backup-size", type=int, default=10000, help="Local backup can't be bigger than 10Go")
 


### PR DESCRIPTION
Our system does not work at night at the moment, so we are looking to disable night alerts. We do it for now by comparing the time to the sunset / sunrise. But this is not very accurate. We use ir cameras and these cameras switch to ir mode at night and therefore produce black and white images. I propose to use this feature to detect the night more accurately. We keep here the option with the time to answer different use case, for example use of non ir cameras.