### PR TITLE
New alerte strategy

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -159,7 +159,7 @@ class Engine:
 
     def clear_cache(self) -> None:
         """Clear local cache"""
-        for file in self._cache.rglob("*"):
+        for file in self._cache.rglob("pending*"):
             file.unlink()
 
     def _dump_cache(self) -> None:
@@ -184,6 +184,7 @@ class Engine:
                     "frame_path": str(self._cache.joinpath(f"pending_frame{idx}.jpg")),
                     "cam_id": info["cam_id"],
                     "ts": info["ts"],
+                    "localization": info["localization"],
                 }
             )
 
@@ -245,7 +246,7 @@ class Engine:
         )
 
         # update state
-        if conf > conf_th:
+        if conf > self.conf_thresh:
             self._states[cam_key]["ongoing"] = True
         else:
             self._states[cam_key]["ongoing"] = False
@@ -273,6 +274,8 @@ class Engine:
         # Reduce image size to save bandwidth
         if isinstance(self.frame_size, tuple):
             frame_resize = frame.resize(self.frame_size[::-1], Image.BILINEAR)
+        else:
+            frame_resize = frame
 
         if is_day_time(self._cache, frame, self.day_time_strategy):
             # Inference with ONNX

--- a/pyroengine/vision.py
+++ b/pyroengine/vision.py
@@ -74,5 +74,7 @@ class Classifier:
         if len(y) > 0:
             y[:, :4:2] /= self.img_size[1]
             y[:, 1:4:2] /= self.img_size[0]
+        else:
+            y = np.zeros((0, 5))  # normalize output
 
         return y

--- a/src/run.py
+++ b/src/run.py
@@ -55,7 +55,7 @@ def main(args):
         frame_saving_period=args.save_period // args.period,
         cache_folder=args.cache,
         backup_size=args.backup_size,
-        alert_relaxation=args.alert_relaxation,
+        nb_consecutive_frames=args.nb_consecutive_frames,
         frame_size=args.frame_size,
         cache_backup_period=args.cache_backup_period,
         cache_size=args.cache_size,
@@ -94,10 +94,10 @@ if __name__ == "__main__":
     parser.add_argument("--jpeg_quality", type=int, default=80, help="Jpeg compression")
     parser.add_argument("--cache-size", type=int, default=20, help="Maximum number of alerts to save in cache")
     parser.add_argument(
-        "--alert_relaxation",
+        "--nb-consecutive_frames",
         type=int,
         default=3,
-        help="Number of consecutive positive detections required to send the first alert",
+        help="Number of consecutive frames to combine for prediction",
     )
     parser.add_argument(
         "--cache_backup_period", type=int, default=60, help="Number of minutes between each cache backup to disk"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pathlib import Path
 
 from dotenv import load_dotenv
+from PIL import Image
 
 from pyroengine.engine import Engine
 
@@ -16,7 +17,7 @@ def test_engine_offline(tmpdir_factory, mock_wildfire_image, mock_forest_image):
 
     # Cache saving
     _ts = datetime.utcnow().isoformat()
-    engine._stage_alert(mock_wildfire_image, 0, localization="dummy")
+    engine._stage_alert(mock_wildfire_image, 0, datetime.utcnow().isoformat(), localization="dummy")
     assert len(engine._alerts) == 1
     assert engine._alerts[0]["ts"] < datetime.utcnow().isoformat() and _ts < engine._alerts[0]["ts"]
     assert engine._alerts[0]["media_id"] is None
@@ -32,6 +33,7 @@ def test_engine_offline(tmpdir_factory, mock_wildfire_image, mock_forest_image):
         "frame_path": str(engine._cache.joinpath("pending_frame0.jpg")),
         "cam_id": 0,
         "ts": engine._alerts[0]["ts"],
+        "localization": "dummy",
     }
     # Overrites cache files
     engine._dump_cache()
@@ -42,21 +44,40 @@ def test_engine_offline(tmpdir_factory, mock_wildfire_image, mock_forest_image):
     engine.clear_cache()
 
     # inference
-    engine = Engine(alert_relaxation=3, cache_folder=folder)
+    engine = Engine(nb_consecutive_frames=4, cache_folder=folder)
     out = engine.predict(mock_forest_image)
     assert isinstance(out, float) and 0 <= out <= 1
-    assert engine._states["-1"]["consec"] == 0
-    out = engine.predict(mock_wildfire_image)
+    assert len(engine._states["-1"]["last_predictions"]) == 1
+    assert engine._states["-1"]["frame_count"] == 0
+    assert engine._states["-1"]["ongoing"] is False
+    assert isinstance(engine._states["-1"]["last_predictions"][0][0], Image.Image)
+    assert engine._states["-1"]["last_predictions"][0][1].shape[0] == 0
+    assert engine._states["-1"]["last_predictions"][0][1].shape[1] == 5
+    assert engine._states["-1"]["last_predictions"][0][2] == "[]"
+    assert engine._states["-1"]["last_predictions"][0][3] < datetime.utcnow().isoformat()
+    assert engine._states["-1"]["last_predictions"][0][4] is False
 
+    out = engine.predict(mock_wildfire_image)
     assert isinstance(out, float) and 0 <= out <= 1
-    assert engine._states["-1"]["consec"] == 1
-    # Alert relaxation
-    assert not engine._states["-1"]["ongoing"]
+    assert len(engine._states["-1"]["last_predictions"]) == 2
+    assert engine._states["-1"]["ongoing"] is False
+    assert isinstance(engine._states["-1"]["last_predictions"][0][0], Image.Image)
+    assert engine._states["-1"]["last_predictions"][1][1].shape[0] > 0
+    assert engine._states["-1"]["last_predictions"][1][1].shape[1] == 5
+    assert engine._states["-1"]["last_predictions"][1][2] == "[]"
+    assert engine._states["-1"]["last_predictions"][1][3] < datetime.utcnow().isoformat()
+    assert engine._states["-1"]["last_predictions"][1][4] is False
+
     out = engine.predict(mock_wildfire_image)
-    assert engine._states["-1"]["consec"] == 2
-    out = engine.predict(mock_wildfire_image)
-    assert engine._states["-1"]["consec"] == 3
-    assert engine._states["-1"]["ongoing"]
+    assert isinstance(out, float) and 0 <= out <= 1
+    assert len(engine._states["-1"]["last_predictions"]) == 3
+    assert engine._states["-1"]["ongoing"] is True
+    assert isinstance(engine._states["-1"]["last_predictions"][0][0], Image.Image)
+    assert engine._states["-1"]["last_predictions"][2][1].shape[0] > 0
+    assert engine._states["-1"]["last_predictions"][2][1].shape[1] == 5
+    assert len(engine._states["-1"]["last_predictions"][-1][2].split(" ")) == 5
+    assert engine._states["-1"]["last_predictions"][2][3] < datetime.utcnow().isoformat()
+    assert engine._states["-1"]["last_predictions"][2][4] is False
 
 
 def test_engine_online(tmpdir_factory, mock_wildfire_stream, mock_wildfire_image):
@@ -76,7 +97,7 @@ def test_engine_online(tmpdir_factory, mock_wildfire_stream, mock_wildfire_image
             cam_creds=cam_creds,
             latitude=float(lat),
             longitude=float(lon),
-            alert_relaxation=2,
+            nb_consecutive_frames=4,
             frame_saving_period=3,
             cache_folder=folder,
             frame_size=(256, 384),
@@ -90,10 +111,14 @@ def test_engine_online(tmpdir_factory, mock_wildfire_stream, mock_wildfire_image
         assert start_ts < json_respone["last_ping"] < ts
         # Send an alert
         engine.predict(mock_wildfire_image, "dummy_cam")
-        assert len(engine._alerts) == 0 and engine._states["dummy_cam"]["consec"] == 1
-        assert engine._states["dummy_cam"]["frame_count"] == 1
+        assert len(engine._states["dummy_cam"]["last_predictions"]) == 1
+        assert len(engine._alerts) == 0
+        assert engine._states["dummy_cam"]["ongoing"] is False
+
         engine.predict(mock_wildfire_image, "dummy_cam")
-        assert engine._states["dummy_cam"]["consec"] == 2 and engine._states["dummy_cam"]["ongoing"]
+        assert len(engine._states["dummy_cam"]["last_predictions"]) == 2
+
+        assert engine._states["dummy_cam"]["ongoing"] is True
         assert engine._states["dummy_cam"]["frame_count"] == 2
         # Check that a media and an alert have been registered
         assert len(engine._alerts) == 0


### PR DESCRIPTION
Hello,

The counter we're currently using poses a problem if we have the following prediction sequence (0: no_fire, 1:fire):

1 0 1 1 0 1 1 1 1

We'll start transmitting images from frame 7 onwards, although the previous images are probably interesting.

What's more, we're not using our model's location information, so two FPs in different places will increase the counter together.

I therefore propose a new strategy, combining the results of N consecutive frames. As shown in the schema below, the idea is to perform an NMS on all the boxes amoung the N frames, then for each resulting box, sum up the score of each box with an intersection >0. In the schema, we sum up all the red boxes to obtain a score of 1.21.

The new detection threshold is conf_th * N, i.e. here 0.25 x 4 = 1. Only the red box is retained.

We then send the 4 frames used to make the prediction, in order not to lose any image.

NB: in this case, at frame 4, the old counter would be at 1, meaning that many images are lost.

![image](https://github.com/pyronear/pyro-engine/assets/17944639/5c160771-23c8-45c7-9813-6802947e524c)
