### PR TITLE
limit bbox size

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -251,6 +251,10 @@ class Engine:
             else:
                 output_predictions = combine_predictions
 
+            # Limit bbox size in api
+            output_predictions = np.round(output_predictions, 3) # max 3 digit
+            output_predictions = output_predictions[:5, :] # max 5 bbox
+
         self._states[cam_key]["last_predictions"].append(
             (frame, preds, str(json.dumps(output_predictions.tolist())), datetime.utcnow().isoformat(), False)
         )

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -252,8 +252,8 @@ class Engine:
                 output_predictions = combine_predictions
 
             # Limit bbox size in api
-            output_predictions = np.round(output_predictions, 3) # max 3 digit
-            output_predictions = output_predictions[:5, :] # max 5 bbox
+            output_predictions = np.round(output_predictions, 3)  # max 3 digit
+            output_predictions = output_predictions[:5, :]  # max 5 bbox
 
         self._states[cam_key]["last_predictions"].append(
             (frame, preds, str(json.dumps(output_predictions.tolist())), datetime.utcnow().isoformat(), False)


### PR DESCRIPTION
Due to a recent api problem, we propose to limit the size of bboxes sent. We send a maximum of 5 boxes with 3 decimals.