### PR TITLE
filter boxes with low score

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -254,6 +254,9 @@ class Engine:
             # Limit bbox size in api
             output_predictions = np.round(output_predictions, 3)  # max 3 digit
             output_predictions = output_predictions[:5, :]  # max 5 bbox
+            output_predictions = output_predictions[
+                output_predictions[:, 4] > self.conf_thresh
+            ]  # send only boxes above conf
 
         self._states[cam_key]["last_predictions"].append(
             (frame, preds, output_predictions.tolist(), datetime.utcnow().isoformat(), False)


### PR DESCRIPTION
From the PR we take into account all boxes with a score > 0.05 to combine them, which allows us to take into account predictions with a score slightly lower than the threshold. However, we don't want to send these boxes to the api, as there's no reason to display them on the platform.