### PR TITLE
fix mypy

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -290,7 +290,7 @@ class Engine:
         cam_key = cam_id or "-1"
         # Reduce image size to save bandwidth
         if isinstance(self.frame_size, tuple):
-            frame_resize = frame.resize(self.frame_size[::-1], Image.BILINEAR)
+            frame_resize = frame.resize(self.frame_size[::-1], getattr(Image, "BILINEAR"))
         else:
             frame_resize = frame
 


### PR DESCRIPTION
Let's fix this mypy issur : 

```
Run mypy --version
mypy 1.9.0 (compiled: yes)
pyroengine/engine.py:293: error: Module has no attribute "BILINEAR" 
[attr-defined]
    ...    frame_resize = frame.resize(self.frame_size[::-1], Image.BILINEAR)
                                                              ^~~~~~~~~~~~~~
Found 1 error in 1 file (checked 7 source files)
Error: Process completed with exit code 1.
```