### PR TITLE
increase timeout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install git -y
 COPY ./src/requirements.txt /tmp/requirements.txt
 RUN apt-get update && apt-get install ffmpeg libsm6 libxext6  -y\
     && pip install --upgrade pip setuptools wheel \
-    && pip install -r /tmp/requirements.txt \
+    && pip install --default-timeout=500 -r /tmp/requirements.txt \
     && pip cache purge \
     && rm -rf /root/.cache/pip
 


### PR DESCRIPTION
from time to time the docker build crashes on some devices due to a pip timeout caused by a bad connection, so I propose to increase the limit 