### PR TITLE
Fix onnx prediction

### DIFF
--- a/pyroengine/utils.py
+++ b/pyroengine/utils.py
@@ -7,7 +7,7 @@
 import numpy as np
 from tqdm import tqdm  # type: ignore[import-untyped]
 
-__all__ = ["letterbox", "nms", "xywh2xyxy", "DownloadProgressBar"]
+__all__ = ["nms", "xywh2xyxy", "DownloadProgressBar"]
 
 
 def xywh2xyxy(x: np.ndarray):

--- a/pyroengine/utils.py
+++ b/pyroengine/utils.py
@@ -4,7 +4,6 @@
 # See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
 
 
-import cv2  # type: ignore[import-untyped]
 import numpy as np
 from tqdm import tqdm  # type: ignore[import-untyped]
 
@@ -18,51 +17,6 @@ def xywh2xyxy(x: np.ndarray):
     y[..., 2] = x[..., 0] + x[..., 2] / 2  # bottom right x
     y[..., 3] = x[..., 1] + x[..., 3] / 2  # bottom right y
     return y
-
-
-def letterbox(
-    im: np.ndarray, new_shape: tuple = (640, 640), color: tuple = (0, 0, 0), auto: bool = False, stride: int = 32
-):
-    """Letterbox image transform for yolo models
-    Args:
-        im (np.ndarray): Input image
-        new_shape (tuple, optional): Image size. Defaults to (640, 640).
-        color (tuple, optional): Pixel fill value for the area outside the transformed image.
-        Defaults to (0, 0, 0).
-        auto (bool, optional): auto padding. Defaults to True.
-        stride (int, optional): padding stride. Defaults to 32.
-    Returns:
-        np.ndarray: Output image
-    """
-    # Resize and pad image while meeting stride-multiple constraints
-    im = np.array(im)
-    shape = im.shape[:2]  # current shape [height, width]
-    if isinstance(new_shape, int):
-        new_shape = (new_shape, new_shape)
-
-    # Scale ratio (new / old)
-    r = min(new_shape[0] / shape[0], new_shape[1] / shape[1])
-
-    # Compute padding
-    new_unpad = int(round(shape[1] * r)), int(round(shape[0] * r))
-    dw, dh = new_shape[1] - new_unpad[0], new_shape[0] - new_unpad[1]  # wh padding
-
-    if auto:  # minimum rectangle
-        dw, dh = np.mod(dw, stride), np.mod(dh, stride)  # wh padding
-
-    dw /= 2  # divide padding into 2 sides
-    dh /= 2
-
-    if shape[::-1] != new_unpad:  # resize
-        im = cv2.resize(im, new_unpad, interpolation=cv2.INTER_LINEAR)
-    top, bottom = int(round(dh - 0.1)), int(round(dh + 0.1))
-    left, right = int(round(dw - 0.1)), int(round(dw + 0.1))
-    # add border
-    h, w = im.shape[:2]
-    im_b = np.zeros((h + top + bottom, w + left + right, 3)) + color
-    im_b[top : top + h, left : left + w, :] = im
-
-    return im_b.astype("uint8"), (left, top)
 
 
 def box_iou(box1: np.ndarray, box2: np.ndarray, eps: float = 1e-7):

--- a/pyroengine/vision.py
+++ b/pyroengine/vision.py
@@ -16,7 +16,7 @@ from .utils import DownloadProgressBar, nms, xywh2xyxy
 
 __all__ = ["Classifier"]
 
-MODEL_URL = "https://huggingface.co/pyronear/yolov8s/resolve/main/yolov8s.onnx"
+MODEL_URL = "https://huggingface.co/pyronear/yolov8s/resolve/main/model.onnx"
 
 
 class Classifier:

--- a/pyroengine/vision.py
+++ b/pyroengine/vision.py
@@ -68,6 +68,7 @@ class Classifier:
         w, h = pil_img.size
         ratio = self.base_img_size / max(w, h)
         new_img_size = (int(ratio * w), int(ratio * h))
+        new_img_size = [x - x % 32 for x in new_img_size]  # size need to be a multiple of 32 to fit the model
         np_img = self.preprocess_image(pil_img, new_img_size)
 
         # ONNX inference

--- a/pyroengine/vision.py
+++ b/pyroengine/vision.py
@@ -44,7 +44,7 @@ class Classifier:
         self.ort_session = onnxruntime.InferenceSession(model_path)
         self.base_img_size = base_img_size
 
-    def preprocess_image(self, pil_img: Image.Image, new_img_size: tuple) -> Tuple[np.ndarray, Tuple[int, int]]:
+    def preprocess_image(self, pil_img: Image.Image, new_img_size: list) -> Tuple[np.ndarray, Tuple[int, int]]:
         """Preprocess an image for inference
 
         Args:
@@ -67,8 +67,8 @@ class Classifier:
 
         w, h = pil_img.size
         ratio = self.base_img_size / max(w, h)
-        new_img_size = (int(ratio * w), int(ratio * h))
-        new_img_size = tuple([x - x % 32 for x in new_img_size])  # size need to be a multiple of 32 to fit the model
+        new_img_size = [int(ratio * w), int(ratio * h)]
+        new_img_size = [x - x % 32 for x in new_img_size]  # size need to be a multiple of 32 to fit the model
         np_img = self.preprocess_image(pil_img, new_img_size)
 
         # ONNX inference

--- a/pyroengine/vision.py
+++ b/pyroengine/vision.py
@@ -68,7 +68,7 @@ class Classifier:
         w, h = pil_img.size
         ratio = self.base_img_size / max(w, h)
         new_img_size = (int(ratio * w), int(ratio * h))
-        new_img_size = [x - x % 32 for x in new_img_size]  # size need to be a multiple of 32 to fit the model
+        new_img_size = tuple([x - x % 32 for x in new_img_size])  # size need to be a multiple of 32 to fit the model
         np_img = self.preprocess_image(pil_img, new_img_size)
 
         # ONNX inference

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -7,10 +7,9 @@ def test_classifier(mock_wildfire_image):
     # Instantiate the ONNX model
     model = Classifier()
     # Check preprocessing
-    out, pad = model.preprocess_image(mock_wildfire_image)
+    out = model.preprocess_image(mock_wildfire_image, (1024, 576))
     assert isinstance(out, np.ndarray) and out.dtype == np.float32
-    assert out.shape == (1, 3, 1024, 1024)
-    assert isinstance(pad, tuple)
+    assert out.shape == (1, 3, 576, 1024)
     # Check inference
     out = model(mock_wildfire_image)
     assert out.shape == (1, 5)
@@ -18,7 +17,7 @@ def test_classifier(mock_wildfire_image):
     assert conf >= 0 and conf <= 1
 
     # Test mask
-    mask = np.ones((1024, 640))
+    mask = np.ones((1024, 576))
     out = model(mock_wildfire_image, mask)
     assert out.shape == (1, 5)
 


### PR DESCRIPTION
Hi, I hadn't done a test with images of different sizes and I realized that the resize was not adapted. We don't need a letterbox (as is the case when training) but simply the following resizing.

I modified the model in onnx format on hugging face by exporting with the “dynamic” parameter to adapt to any image size. The dimensions simply have to be a multiple of 32