### PR TITLE
add max bbox size

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -81,6 +81,7 @@ class Engine:
         self,
         model_path: Optional[str] = None,
         conf_thresh: float = 0.15,
+        max_bbox_size: float = 0.4,
         api_url: Optional[str] = None,
         cam_creds: Optional[Dict[str, Dict[str, str]]] = None,
         latitude: Optional[float] = None,
@@ -100,7 +101,7 @@ class Engine:
         """Init engine"""
         # Engine Setup
 
-        self.model = Classifier(model_path=model_path, conf=0.05)
+        self.model = Classifier(model_path=model_path, conf=0.05, max_bbox_size=max_bbox_size)
         self.conf_thresh = conf_thresh
 
         # API Setup

--- a/pyroengine/vision.py
+++ b/pyroengine/vision.py
@@ -210,6 +210,11 @@ class Classifier:
 
         pred = self.post_process(pred, pad)
 
+        # drop big detections
+        pred = np.clip(pred, 0, 1)
+        pred = pred[(pred[:, 2] - pred[:, 0]) > 0.4, :]
+        pred = np.reshape(pred, (-1, 5))
+
         # Remove prediction in occlusion mask
         if occlusion_mask is not None:
             hm, wm = occlusion_mask.shape

--- a/pyroengine/vision.py
+++ b/pyroengine/vision.py
@@ -47,7 +47,9 @@ class Classifier:
         model_path: model path
     """
 
-    def __init__(self, model_folder="data", imgsz=1024, conf=0.15, iou=0, format="ncnn", model_path=None) -> None:
+    def __init__(
+        self, model_folder="data", imgsz=1024, conf=0.15, iou=0, format="ncnn", model_path=None, max_bbox_size=0.4
+    ) -> None:
         if model_path is None:
 
             if format == "ncnn":
@@ -103,6 +105,7 @@ class Classifier:
         self.imgsz = imgsz
         self.conf = conf
         self.iou = iou
+        self.max_bbox_size = max_bbox_size
 
     def is_arm_architecture(self):
         # Check for ARM architecture
@@ -221,7 +224,7 @@ class Classifier:
 
         # drop big detections
         pred = np.clip(pred, 0, 1)
-        pred = pred[(pred[:, 2] - pred[:, 0]) > 0.4, :]
+        pred = pred[(pred[:, 2] - pred[:, 0]) < self.max_bbox_size, :]
         pred = np.reshape(pred, (-1, 5))
 
         # Remove prediction in occlusion mask

--- a/src/run.py
+++ b/src/run.py
@@ -54,6 +54,7 @@ def main(args):
     engine = Engine(
         args.model_path,
         args.thresh,
+        args.max_bbox_size,
         API_URL,
         splitted_cam_creds,
         LAT,
@@ -84,6 +85,8 @@ if __name__ == "__main__":
     # Model
     parser.add_argument("--model_path", type=str, default=None, help="model path")
     parser.add_argument("--thresh", type=float, default=0.15, help="Confidence threshold")
+    parser.add_argument("--max_bbox_size", type=float, default=0.4, help="Maximum bbox size")
+
     # Camera & cache
     parser.add_argument("--creds", type=str, default="data/credentials.json", help="Camera credentials")
     parser.add_argument("--cache", type=str, default="./data", help="Cache folder")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from PIL import Image
 
 @pytest.fixture(scope="session")
 def mock_wildfire_stream(tmpdir_factory):
-    url = "https://github.com/pyronear/pyro-engine/releases/download/v0.1.1/forest_sample.jpg"
+    url = "https://github.com/pyronear/pyro-engine/releases/download/v0.1.1/fire_sample_image.jpg"
     return requests.get(url).content
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from PIL import Image
 
 @pytest.fixture(scope="session")
 def mock_wildfire_stream(tmpdir_factory):
-    url = "https://github.com/pyronear/pyro-vision/releases/download/v0.1.2/fire_sample_image.jpg"
+    url = "https://github.com/pyronear/pyro-engine/releases/download/v0.1.1/forest_sample.jpg"
     return requests.get(url).content
 
 


### PR DESCRIPTION
After an analysis of the fires of the past year, none exceeded 20% of the image in width, so I suggest filtering out the detections that represent more than 40% of the image (to keep a margin), which are only produced by large clouds that the current model is still mistaken about