### PR TITLE
New model

### DIFF
--- a/pyroengine/vision.py
+++ b/pyroengine/vision.py
@@ -21,9 +21,9 @@ from .utils import DownloadProgressBar, letterbox, nms, xywh2xyxy
 
 __all__ = ["Classifier"]
 
-MODEL_URL_FOLDER = "https://huggingface.co/pyronear/yolov8s/resolve/main/"
-MODEL_ID = "pyronear/yolov8s"
-MODEL_NAME = "yolov8s.pt"
+MODEL_URL_FOLDER = "https://huggingface.co/pyronear/yolov11s/resolve/main/"
+MODEL_ID = "pyronear/yolov11s"
+MODEL_NAME = "yolov11s.pt"
 METADATA_NAME = "model_metadata.json"
 
 
@@ -63,11 +63,11 @@ class Classifier:
                 if not self.is_arm_architecture():
                     logging.info("NCNN format is optimized for arm architecture only, switching to onnx is recommended")
 
-                model = "yolov8s_ncnn_model.zip"
+                model = "yolov11s_ncnn_model.zip"
                 self.format = "ncnn"
 
             elif format == "onnx":
-                model = "yolov8s.onnx"
+                model = "yolov11s.onnx"
                 self.format = "onnx"
 
             model_path = os.path.join(model_folder, model)

--- a/src/run.py
+++ b/src/run.py
@@ -82,7 +82,7 @@ if __name__ == "__main__":
     )
     # Model
     parser.add_argument("--model_path", type=str, default=None, help="model path")
-    parser.add_argument("--thresh", type=float, default=0.15, help="Confidence threshold")
+    parser.add_argument("--thresh", type=float, default=0.16, help="Confidence threshold")
     parser.add_argument("--max_bbox_size", type=float, default=0.4, help="Maximum bbox size")
 
     # Camera & cache

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -159,7 +159,6 @@ def test_engine_online(tmpdir_factory, mock_wildfire_stream, mock_wildfire_image
             nb_consecutive_frames=4,
             frame_saving_period=3,
             cache_folder=folder,
-            frame_size=(256, 384),
         )
         # Heartbeat
         start_ts = datetime.now(timezone.utc).isoformat()
@@ -178,6 +177,9 @@ def test_engine_online(tmpdir_factory, mock_wildfire_stream, mock_wildfire_image
 
         engine.predict(mock_wildfire_image, "dummy_cam")
         assert len(engine._states["dummy_cam"]["last_predictions"]) == 2
+
+        engine.predict(mock_wildfire_image, "dummy_cam")
+        assert len(engine._states["dummy_cam"]["last_predictions"]) == 3
 
         assert engine._states["dummy_cam"]["ongoing"] is True
         # Check that a media and an alert have been registered

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -38,7 +38,7 @@ def test_classifier(tmpdir_factory, mock_wildfire_image):
 
     # Test onnx model
     model = Classifier(model_folder=folder, format="onnx")
-    model_path = os.path.join(folder, "yolov8s.onnx")
+    model_path = os.path.join(folder, "yolov11s.onnx")
     assert os.path.isfile(model_path)
 
     # Test mask
@@ -60,7 +60,7 @@ def test_download(tmpdir_factory):
     # Instantiate the ONNX model
     _ = Classifier(model_folder=folder, format="onnx")
 
-    model_path = os.path.join(folder, "yolov8s.onnx")
+    model_path = os.path.join(folder, "yolov11s.onnx")
     model_creation_date = get_creation_date(model_path)
 
     # No download if exist


### PR DESCRIPTION

Pr for model change

After the latest training on the new wildfire_2025 dataset, we have a new, much higher-performance model: on our new test ds, we go from 


   Prediction Folder | Best Threshold | Best F1 Score | Precision | Recall
 -- | -- | -- | -- | --
Test_dataset_2025_e363f23c | 0.16 | 0.827610 | 0.820960 | 0.834369
Test_dataset_2025_yolov8s | 0.07 | 0.685367 | 0.628890 | 0.752990



