### PR TITLE
Update nb of consecutive frames to 8

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -83,7 +83,7 @@ class Engine:
         max_bbox_size: float = 0.4,
         api_url: Optional[str] = None,
         cam_creds: Optional[Dict[str, Dict[str, str]]] = None,
-        nb_consecutive_frames: int = 4,
+        nb_consecutive_frames: int = 8,
         frame_size: Optional[Tuple[int, int]] = None,
         cache_backup_period: int = 60,
         frame_saving_period: Optional[int] = None,

--- a/src/run.py
+++ b/src/run.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--nb-consecutive_frames",
         type=int,
-        default=6,
+        default=8,
         help="Number of consecutive frames to combine for prediction",
     )
     parser.add_argument(


### PR DESCRIPTION
The engine takes into account several consecutive frames to average the predicitons made by the model. After having tested several values of this parameters with the EvaluationPipeline (https://github.com/earthtoolsmaker/pyro-eval), we notice that setting this parameter to 8 allows to avoid several false positives (-30%) while conserving most detections (-1.5%). Tests have been performed on 70 sequences of fire and 70 sequences of false positive.
Test details are available here:

https://docs.google.com/spreadsheets/d/1v_u4cCko0vaGM2iV7nkdmvA5s_YBXFhalXDmcuKZ_6A/edit?gid=2071703334#gid=2071703334
or
[Pyro Metrics.xlsx](https://github.com/user-attachments/files/20688464/Pyro.Metrics.xlsx)
