### PR TITLE
Improve bbox fallback handling in engine

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -330,7 +330,8 @@ class Engine:
 
     def fill_empty_bboxes(self):
         # Group alerts by cam_id
-        cam_id_to_indices = {}
+        cam_id_to_indices: Dict[str, list[int]] = {}
+
         for i, alert in enumerate(self._alerts):
             cam_id = alert["cam_id"]
             if cam_id not in cam_id_to_indices:


### PR DESCRIPTION
This PR improves the robustness of alert generation by ensuring that each frame added to the last_predictions buffer includes bounding boxes, even when the current prediction is empty.

Fallback bboxes are now filled directly in _update_states() from the latest valid detection for the same camera.

This change removes the need to wait for post-processing to fix empty bboxes during _process_alerts().

fill_empty_bboxes() is still kept in case older alerts in the queue need patching (e.g., if engine is restarted).

Ensures alerts are never uploaded with empty bboxes, which could cause API rejections
This change guarantees per-camera consistency and prevents bbox leakage across different camera streams

