### PR TITLE
Bugfix - Specify dtype on iou_match for empty preds

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -193,7 +193,7 @@ class Engine:
 
                 if combine_predictions.shape[0] > 0:
                     ious = box_iou(combine_predictions[:, :4], preds[:, :4])
-                    iou_match = np.array([np.max(iou) > 0 for iou in ious])
+                    iou_match = np.array([np.max(iou) > 0 for iou in ious], dtype=bool)
                     matched_preds = preds[iou_match, :]
                     if matched_preds.ndim == 1:
                         matched_preds = matched_preds[np.newaxis, :]


### PR DESCRIPTION
When executing predictions the following error was encountered:

engine/pyroengine/engine.py", line 199, in updatestates
    matched_preds = preds[iou_match, :]
IndexError: arrays used as indices must be of integer (or boolean) type

The former declaration of iou_match did not specify any type, which, for an empty prediciton, would create an empty array of dtype object, which cannot be used to index another array.

This is fixed by specifying dtype=bool:
`iou_match = np.array([np.max(iou) > 0 for iou in ious], dtype=bool)`