### PR TITLE
no init move

### DIFF
--- a/reolink_api/src/reolink.py
+++ b/reolink_api/src/reolink.py
@@ -63,10 +63,6 @@ class ReolinkCamera:
         self.focus_position = focus_position
         self.last_images: dict[int, Image.Image] = {}
 
-        # Initialisation de position de caméra (si définie)
-        if self.cam_poses:
-            self.move_camera("ToPos", idx=int(self.cam_poses[0]), speed=50)
-
     def _build_url(self, command: str) -> str:
         """Constructs a URL for API commands to the camera."""
         return (


### PR DESCRIPTION
Problem

On Pi reboot, the FastAPI app crashed because ReolinkCamera.__init__ performed a network call (move_camera("ToPos", ...)) during import time. At that moment, the link-local cameras (169.254.x.x) are not yet reachable from inside the container, leading to ConnectionError: No route to host. Since this happened during module import, uvicorn’s reloader could not start the app.

Fix

Removed the initial camera move from the constructor. The camera will now remain in its current position at startup, and patrol/static loops or API calls can move it later when the network is ready. This avoids network calls during import and ensures the service always starts cleanly after reboot.