### PR TITLE
Fix start up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,45 +1,41 @@
 services:
-
   reolink-api:
-    image: pyronear/reolink-api:latest
     build:
       context: ./reolink_api
+    image: pyronear/reolink-api:latest
     container_name: reolink-api
     environment:
-      - CAM_USER=${CAM_USER}
-      - CAM_PWD=${CAM_PWD}
-      - MEDIAMTX_SERVER_IP=${MEDIAMTX_SERVER_IP}
+      CAM_USER: ${CAM_USER}
+      CAM_PWD: ${CAM_PWD}
+      MEDIAMTX_SERVER_IP: ${MEDIAMTX_SERVER_IP}
     volumes:
       - ./data:/usr/src/app/data
-    command: "uvicorn main:app --reload --host 0.0.0.0 --port 8081"
+    command: uvicorn main:app --host 0.0.0.0 --port 8081
     restart: always
     network_mode: host
     logging:
-      driver: "json-file"
+      driver: json-file
       options:
         max-size: "100m"
         max-file: "5"
 
   engine:
+    build:
+      context: ./engine
     image: pyronear/pyro-engine:latest
     container_name: engine
     environment:
-      - API_URL=${API_URL}
-      - CAM_USER=${CAM_USER}
-      - CAM_PWD=${CAM_PWD}
-      - MEDIAMTX_SERVER_IP=${MEDIAMTX_SERVER_IP}
-    command: >
-      sh -c '
-        echo "Sleeping 15 seconds to wait for reolink-api to capture one image per pose...";
-        sleep 15;
-        python run.py
-      '
+      API_URL: ${API_URL}
+      CAM_USER: ${CAM_USER}
+      CAM_PWD: ${CAM_PWD}
+      MEDIAMTX_SERVER_IP: ${MEDIAMTX_SERVER_IP}
     volumes:
       - ./data:/usr/src/app/data
+    command: python run.py
     restart: always
     network_mode: host
     logging:
-      driver: "json-file"
+      driver: json-file
       options:
         max-size: "100m"
         max-file: "5"

--- a/pyroengine/core.py
+++ b/pyroengine/core.py
@@ -123,6 +123,7 @@ class SystemController:
         self.last_autofocus: Optional[datetime] = None
 
         # 1. Loop until API client is actually usable
+        time.sleep(30)  # let api start
         while True:
             try:
                 logging.info("wait api ...")
@@ -133,8 +134,8 @@ class SystemController:
                 logging.info("Reolink API client ready")
                 break
             except Exception as e:
-                logging.error(f"API not ready: {e}")
-                time.sleep(30)
+                logging.error(f"API not ready ...: {e}")
+                time.sleep(10)
 
         # optional startup actions, do not fail hard
         for ip in self.camera_data.keys():
@@ -149,6 +150,7 @@ class SystemController:
             logging.info("No MediaMTX server IP provided, skipping levée de doute checks.")
 
         # 2. Loop until inference loop runs without throwing
+        time.sleep(10)
         while True:
             try:
                 logging.info("waiting cam ...")
@@ -156,7 +158,7 @@ class SystemController:
                 break
             except Exception as e:
                 logging.error(f"Inference failed: {e}")
-                time.sleep(30)
+                time.sleep(10)
 
         if self.mediamtx_server_ip:
             logging.info(f"Using MediaMTX server IP: {self.mediamtx_server_ip}")

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -308,8 +308,8 @@ class Engine:
                     bbox_mask_dict = response.json()
                     self.occlusion_masks[cam_key] = (bbox_mask_url, bbox_mask_dict, azimuth)
                     logging.info(f"Downloaded occlusion masks for cam {cam_key} at {bbox_mask_url} :{bbox_mask_dict}")
-                except requests.exceptions.RequestException as e:
-                    logging.error(f"Failed to download the JSON file: {e}")
+                except requests.exceptions.RequestException:
+                    logging.info(f"No occluson available for: {cam_key}")
 
         # Inference with ONNX
         if fake_pred is None:

--- a/reolink_api/client/reolink_api_client/client.py
+++ b/reolink_api/client/reolink_api_client/client.py
@@ -34,10 +34,11 @@ class ReolinkAPIClient:
         resp.raise_for_status()
         return Image.open(BytesIO(resp.content))
 
-    def get_latest_image(self, camera_ip: str, pose: int) -> Image.Image:
-        """Fetches the last captured image for a given pose from memory."""
+    def get_latest_image(self, camera_ip: str, pose: int) -> Optional[Image.Image]:
         params = {"camera_ip": camera_ip, "pose": pose}
         resp = requests.get(f"{self.base_url}/capture/latest_image", params=params)
+        if resp.status_code == 204:
+            return None
         resp.raise_for_status()
         return Image.open(BytesIO(resp.content))
 

--- a/reolink_api/src/camera/capture.py
+++ b/reolink_api/src/camera/capture.py
@@ -11,7 +11,7 @@ from typing import Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 from anonymizer.vision import Anonymizer
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Response, status
 from fastapi.responses import Response
 from PIL import Image
 
@@ -109,8 +109,8 @@ def get_latest_image(camera_ip: str, pose: int):
     cam = CAMERA_REGISTRY[camera_ip]
 
     if pose not in cam.last_images or cam.last_images[pose] is None:
-        # Return 200 OK with empty content
-        return Response(content=b"", media_type="image/jpeg")
+        # Explicitly signal "nothing yet"
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     buffer = BytesIO()
     cam.last_images[pose].save(buffer, format="JPEG")

--- a/reolink_api/src/camera/capture.py
+++ b/reolink_api/src/camera/capture.py
@@ -109,7 +109,8 @@ def get_latest_image(camera_ip: str, pose: int):
     cam = CAMERA_REGISTRY[camera_ip]
 
     if pose not in cam.last_images or cam.last_images[pose] is None:
-        raise HTTPException(status_code=404, detail="No image available for this pose")
+        # Return 200 OK with empty content
+        return Response(content=b"", media_type="image/jpeg")
 
     buffer = BytesIO()
     cam.last_images[pose].save(buffer, format="JPEG")

--- a/src/run.py
+++ b/src/run.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
 
     # Camera & cache
 
-    parser.add_argument("--reolink_api_url", type=str, default="http://0.0.0.0:8081", help="Camera api url")
+    parser.add_argument("--reolink_api_url", type=str, default="http://127.0.0.1:8081", help="Camera api url")
     parser.add_argument("--creds", type=str, default="data/credentials.json", help="Camera credentials")
     parser.add_argument("--cache", type=str, default="./data", help="Cache folder")
     parser.add_argument(


### PR DESCRIPTION
The purpose of this PR is to handle the startup process. We wait for the API to start properly before launching the engine to avoid arbitrary sleeps and error messages.
We also prevent read errors with _safe_get_latest_image