### PR TITLE
Fetch occlusion masks from pyroclient API instead of S3

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -225,8 +225,8 @@ class Engine(Predictor):
                             bbox_mask_dict[str(mask_entry["id"])] = coords
                         self.occlusion_masks[cam_key] = bbox_mask_dict
                         logger.info(f"Downloaded occlusion masks for cam {cam_key}: {bbox_mask_dict}")
-                    except RequestException:
-                        logger.info(f"No occlusion masks available for: {cam_key}")
+                    except RequestException as e:
+                        logger.warning(f"Failed to fetch occlusion masks for cam {cam_key} (pose {pose_id}): {e}")
 
         # Inference with ONNX
         if fake_pred is None:

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -13,11 +13,11 @@ from pathlib import Path
 from typing import Any, Dict, Never, Optional, Tuple
 
 import numpy as np
-import requests
 from PIL import Image
 from pyro_predictor import Predictor
 from pyroclient import client
 from requests.exceptions import ConnectionError as RequestsConnectionError
+from requests.exceptions import RequestException
 from requests.models import Response
 
 __all__ = ["Engine"]
@@ -112,7 +112,7 @@ class Engine(Predictor):
         self.api_client: dict[str, Any] = {}
         if isinstance(api_url, str) and isinstance(cam_creds, dict):
             # Instantiate clients for each camera
-            for id_, (camera_token, _, _) in cam_creds.items():
+            for id_, (camera_token, _) in cam_creds.items():
                 ip = id_.split("_")[0]
                 if ip not in self.api_client:
                     self.api_client[ip] = client.Client(camera_token, api_url)
@@ -136,11 +136,8 @@ class Engine(Predictor):
             state["last_image_sent"] = None
             state["last_bbox_mask_fetch"] = None
 
-        # Occlusion masks
-        self.occlusion_masks: Dict[str, Tuple[Optional[str], Dict[Any, Any], str]] = {"-1": (None, {}, "0")}
-        if isinstance(cam_creds, dict):
-            for cam_id, (_, pose_id, bbox_mask_url) in cam_creds.items():
-                self.occlusion_masks[cam_id] = (bbox_mask_url, {}, pose_id)
+        # Occlusion masks: cam_id -> dict of bboxes (keyed by mask id)
+        self.occlusion_masks: Dict[str, Dict[Any, Any]] = {}
 
         # Restore pending alerts cache
         self._alerts: deque = deque(maxlen=cache_size)
@@ -206,28 +203,34 @@ class Engine(Predictor):
                     response = self.api_client[ip].update_last_image(stream.getvalue())
                     logger.info(response.text)
 
-        # Update occlusion masks
+        # Update occlusion masks from API
         if (
             self._states[cam_key]["last_bbox_mask_fetch"] is None
             or time.time() - self._states[cam_key]["last_bbox_mask_fetch"] > self.last_bbox_mask_fetch_period
         ):
             logger.info(f"Update occlusion masks for cam {cam_key}")
             self._states[cam_key]["last_bbox_mask_fetch"] = time.time()
-            bbox_mask_url, bbox_mask_dict, pose_id = self.occlusion_masks[cam_key]
-            if bbox_mask_url is not None:
-                full_url = f"{bbox_mask_url}_{pose_id}.json"
-                try:
-                    response = requests.get(full_url, timeout=5)
-                    response.raise_for_status()
-                    bbox_mask_dict = response.json()
-                    self.occlusion_masks[cam_key] = (bbox_mask_url, bbox_mask_dict, pose_id)
-                    logger.info(f"Downloaded occlusion masks for cam {cam_key} at {bbox_mask_url} :{bbox_mask_dict}")
-                except requests.exceptions.RequestException:
-                    logger.info(f"No occlusion masks available for: {cam_key}")
+            if isinstance(cam_id, str) and cam_id in self.cam_creds:
+                _, pose_id = self.cam_creds[cam_id]
+                ip = cam_id.split("_")[0]
+                if ip in self.api_client:
+                    try:
+                        response = self.api_client[ip].list_pose_masks(pose_id)
+                        response.raise_for_status()
+                        masks_data = response.json()
+                        bbox_mask_dict: Dict[Any, Any] = {}
+                        for mask_entry in masks_data:
+                            mask_str = mask_entry["mask"].strip("()")
+                            coords = tuple(float(c) for c in mask_str.split(","))
+                            bbox_mask_dict[str(mask_entry["id"])] = coords
+                        self.occlusion_masks[cam_key] = bbox_mask_dict
+                        logger.info(f"Downloaded occlusion masks for cam {cam_key}: {bbox_mask_dict}")
+                    except RequestException:
+                        logger.info(f"No occlusion masks available for: {cam_key}")
 
         # Inference with ONNX
         if fake_pred is None:
-            _, bbox_mask_dict, _ = self.occlusion_masks[cam_key]
+            bbox_mask_dict = self.occlusion_masks.get(cam_key, {})
             preds = self.model(frame.convert("RGB"), bbox_mask_dict)
         else:
             if fake_pred.size == 0:
@@ -319,7 +322,7 @@ class Engine(Predictor):
                     stream = io.BytesIO()
                     frame_info["frame"].save(stream, format="JPEG", quality=self.jpeg_quality)
                     bboxes = [tuple(bboxe) for bboxe in bboxes]
-                    _, pose_id, _ = self.cam_creds[cam_id]
+                    _, pose_id = self.cam_creds[cam_id]
                     ip = cam_id.split("_")[0]
                     response = self.api_client[ip].create_detection(stream.getvalue(), bboxes, pose_id)
 

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -210,7 +210,7 @@ class Engine(Predictor):
         ):
             logger.info(f"Update occlusion masks for cam {cam_key}")
             self._states[cam_key]["last_bbox_mask_fetch"] = time.time()
-            if isinstance(cam_id, str) and cam_id in self.cam_creds:
+            if isinstance(cam_id, str) and isinstance(self.cam_creds, dict) and cam_id in self.cam_creds:
                 _, pose_id = self.cam_creds[cam_id]
                 ip = cam_id.split("_")[0]
                 if ip in self.api_client:

--- a/src/run.py
+++ b/src/run.py
@@ -57,17 +57,13 @@ def main(args):
 
     splitted_cam_creds = {}
     for ip, cam_data in camera_data.items():
-        bbox_mask_url = None
-        if "bbox_mask_url" in cam_data:
-            bbox_mask_url = cam_data["bbox_mask_url"]
-
         if cam_data["type"] == "ptz":
             cam_poses = cam_data["poses"]
             cam_pose_ids = cam_data["pose_ids"]
             for patrol_id, pose_id in zip(cam_poses, cam_pose_ids, strict=False):
-                splitted_cam_creds[ip + "_" + str(patrol_id)] = (cam_data["token"], pose_id, bbox_mask_url)
+                splitted_cam_creds[ip + "_" + str(patrol_id)] = (cam_data["token"], pose_id)
         else:
-            splitted_cam_creds[ip] = cam_data["token"], cam_data["pose_ids"][0], bbox_mask_url
+            splitted_cam_creds[ip] = (cam_data["token"], cam_data["pose_ids"][0])
 
     engine = Engine(
         model_path=args.model_path,

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -145,7 +145,7 @@ def test_engine_online(tmpdir_factory, mock_wildfire_stream, mock_wildfire_image
     # With API
     load_dotenv(Path(__file__).parent.parent.joinpath(".env").absolute())
     api_url = os.environ.get("API_URL")
-    cam_creds = {"dummy_cam": (os.environ.get("API_TOKEN"), 66, None)}
+    cam_creds = {"dummy_cam": (os.environ.get("API_TOKEN"), 66)}
     # Skip the API-related tests if the URL is not specified
 
     if isinstance(api_url, str):
@@ -192,7 +192,7 @@ def test_process_alerts_respects_save_detections_flag(tmp_path, save_detections_
     if not api_url or not api_token:
         pytest.skip("API_URL and API_TOKEN must be set to run this test against the real API")
 
-    cam_creds = {"dummy_cam": (api_token, 0, None)}
+    cam_creds = {"dummy_cam": (api_token, 0)}
     engine = Engine(
         api_url=api_url,
         cache_folder=str(tmp_path),
@@ -272,8 +272,7 @@ def test_engine_occlusion(tmpdir_factory, mock_wildfire_stream, mock_wildfire_im
     # With API
     load_dotenv(Path(__file__).parent.parent.joinpath(".env").absolute())
     api_url = os.environ.get("API_URL")
-    bbox_mask_url = "https://github.com/pyronear/pyro-engine/releases/download/v0.1.1/test_occlusion_bboxes"
-    cam_creds = {"dummy_cam": (os.environ.get("API_TOKEN"), 0, bbox_mask_url)}
+    cam_creds = {"dummy_cam": (os.environ.get("API_TOKEN"), 0)}
     # Skip the API-related tests if the URL is not specified
 
     if isinstance(api_url, str):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -272,7 +272,8 @@ def test_engine_occlusion(tmpdir_factory, mock_wildfire_stream, mock_wildfire_im
     # With API
     load_dotenv(Path(__file__).parent.parent.joinpath(".env").absolute())
     api_url = os.environ.get("API_URL")
-    cam_creds = {"dummy_cam": (os.environ.get("API_TOKEN"), 0)}
+    # Use pose 356 which has an occlusion mask "(0.0,0.5,0.05,0.65)" covering the model's prediction area
+    cam_creds = {"dummy_cam": (os.environ.get("API_TOKEN"), 356)}
     # Skip the API-related tests if the URL is not specified
 
     if isinstance(api_url, str):
@@ -284,9 +285,6 @@ def test_engine_occlusion(tmpdir_factory, mock_wildfire_stream, mock_wildfire_im
             frame_saving_period=3,
             cache_folder=folder,
         )
-        # Inject an occlusion mask covering the model's prediction area
-        engine.occlusion_masks["dummy_cam"] = {"1": (0.0, 0.5, 0.05, 0.65)}
-
         # Heartbeat
         start_ts = datetime.now(timezone.utc).isoformat()
         response = engine.heartbeat("dummy_cam")
@@ -296,8 +294,13 @@ def test_engine_occlusion(tmpdir_factory, mock_wildfire_stream, mock_wildfire_im
         ts = datetime.now(timezone.utc).isoformat()
 
         assert start_ts < json_respone["last_active_at"] < ts
-        # Send an alert
+
+        # First predict triggers the occlusion mask fetch from the API
         engine.predict(mock_wildfire_image, "dummy_cam")
+        # Verify masks were fetched and parsed correctly
+        assert "dummy_cam" in engine.occlusion_masks
+        assert len(engine.occlusion_masks["dummy_cam"]) > 0
+
         assert len(engine._states["dummy_cam"]["last_predictions"]) == 1
         assert len(engine._alerts) == 0
         assert engine._states["dummy_cam"]["ongoing"] is False
@@ -308,4 +311,5 @@ def test_engine_occlusion(tmpdir_factory, mock_wildfire_stream, mock_wildfire_im
         engine.predict(mock_wildfire_image, "dummy_cam")
         assert len(engine._states["dummy_cam"]["last_predictions"]) == 3
 
+        # Predictions are filtered by the occlusion mask, so no wildfire is detected
         assert engine._states["dummy_cam"]["ongoing"] is False

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -284,6 +284,9 @@ def test_engine_occlusion(tmpdir_factory, mock_wildfire_stream, mock_wildfire_im
             frame_saving_period=3,
             cache_folder=folder,
         )
+        # Inject an occlusion mask covering the model's prediction area
+        engine.occlusion_masks["dummy_cam"] = {"1": (0.0, 0.5, 0.05, 0.65)}
+
         # Heartbeat
         start_ts = datetime.now(timezone.utc).isoformat()
         response = engine.heartbeat("dummy_cam")


### PR DESCRIPTION
  - Replace S3-based occlusion mask fetching with pyroclient API (list_pose_masks())                       
  - Simplify cam_creds from 3-tuple (token, pose_id, bbox_mask_url) to 2-tuple (token, pose_id) across
  engine, entrypoint, and tests                                                                            
  - Parse new API response format ("mask": "(x1,y1,x2,y2)") into bbox dicts consumed by the classifier