### PR TITLE
watchdog: load device-specific IPs from env file generated by Ansible

### DIFF
--- a/watchdog/main_pi/watchdog.py
+++ b/watchdog/main_pi/watchdog.py
@@ -23,7 +23,27 @@ import RPi.GPIO as GPIO
 # ================= CONFIG =================
 
 RELAY_PIZERO = 16
-PIZERO_IP = "192.168.1.98"
+
+_ENV_FILE = Path("/home/pi/watchdog.env")
+
+
+def _load_env(path: Path) -> dict:
+    env: dict = {}
+    try:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key, _, value = line.partition("=")
+            env[key.strip()] = value.strip()
+    except FileNotFoundError:
+        pass
+    return env
+
+
+_env = _load_env(_ENV_FILE)
+
+PIZERO_IP: str = _env.get("PIZERO_IP", "192.168.1.98")
 
 PING_COUNT = 2
 TIMEOUT = 2  # seconds, used for ping timeout

--- a/watchdog/pi_zero/watchdog.py
+++ b/watchdog/pi_zero/watchdog.py
@@ -29,10 +29,33 @@ import RPi.GPIO as GPIO
 RELAY_MAIN = 16
 RELAY_CAMS = 26
 
-MAIN_PI_IP = "192.168.1.99"
+_ENV_FILE = Path("/home/pi/watchdog.env")
+
+
+def _load_env(path: Path) -> dict:
+    env: dict = {}
+    try:
+        for line in path.read_text().splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            key, _, value = line.partition("=")
+            env[key.strip()] = value.strip()
+    except FileNotFoundError:
+        pass
+    return env
+
+
+_env = _load_env(_ENV_FILE)
+
+MAIN_PI_IP: str = _env.get("MAIN_PI_IP", "192.168.1.99")
 MAIN_HEALTH_URL = f"http://{MAIN_PI_IP}:8081/health"
 
-CAM_IPS = ["192.168.1.11", "192.168.1.12"]
+_cam_ips_raw = _env.get("CAM_IPS", "")
+CAM_IPS: list[str] = [ip.strip() for ip in _cam_ips_raw.split(",") if ip.strip()] or [
+    "192.168.1.11",
+    "192.168.1.12",
+]
 INTERNET_IP = "1.1.1.1"
 
 PING_COUNT = 2


### PR DESCRIPTION
## Pitch

- `MAIN_PI_IP` and `CAM_IPS` were hardcoded in `watchdog.py`, making the
  same script require manual edits per device
- The Pi Zero watchdog is deployed via Ansible (pi-manager-template), which
  now generates `/home/pi/watchdog.env` with the correct values per device
- `watchdog.py` reads that file at startup and overrides the two variables;
  hardcoded values remain as fallbacks so the script still works standalone

### Why no python-dotenv

The env file is generated by Ansible and intentionally kept to a trivial
`key=value` format — no interpolation, no quoted strings, no multi-line
values. Adding `python-dotenv` for two scalar overrides would be unnecessary
weight on a constrained Pi Zero. The 10-line manual parser covers the exact
format we control and nothing more.

### Env file format (generated by Ansible)

MAIN_PI_IP=192.168.1.99
CAM_IPS=192.168.1.11,192.168.1.12


