### PR TITLE
encode JPEG once in predict so model and uploaded media see identical…

### DIFF
--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -79,7 +79,13 @@ class Predictor:
             "miss_count": 0,
         }
 
-    def _update_states(self, frame: Image.Image, preds: np.ndarray, cam_key: str) -> float:
+    def _update_states(
+        self,
+        frame: Image.Image,
+        preds: np.ndarray,
+        cam_key: str,
+        encoded_bytes: Optional[bytes] = None,
+    ) -> float:
         prev_ongoing = self._states[cam_key]["ongoing"]
 
         conf_th = self.conf_thresh * self.nb_consecutive_frames
@@ -88,7 +94,7 @@ class Predictor:
 
         boxes = np.zeros((0, 5), dtype=np.float64)
         boxes = np.concatenate([boxes, preds])
-        for _, box, _, _, _ in self._states[cam_key]["last_predictions"]:
+        for _, box, _, _, _, _ in self._states[cam_key]["last_predictions"]:
             if box.shape[0] > 0:
                 boxes = np.concatenate([boxes, box])
 
@@ -150,6 +156,7 @@ class Predictor:
             output_predictions.tolist(),  # [] if empty
             datetime.now(timezone.utc).isoformat(),
             False,
+            encoded_bytes,
         ))
 
         new_ongoing = conf > self.conf_thresh
@@ -188,7 +195,9 @@ class Predictor:
             self._states[cam_key] = self._new_state()
 
         if isinstance(self.frame_size, tuple):
-            frame = frame.resize(self.frame_size[::-1], Image.BILINEAR)  # type: ignore[attr-defined]
+            target = (self.frame_size[1], self.frame_size[0])  # PIL expects (W, H)
+            if frame.size != target:
+                frame = frame.resize(target, Image.BILINEAR)  # type: ignore[attr-defined]
 
         if fake_pred is None:
             preds = self.model(frame.convert("RGB"), occlusion_bboxes or {})

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -184,7 +184,17 @@ class Engine(Predictor):
 
         # Reduce image size to save bandwidth
         if isinstance(self.frame_size, tuple):
-            frame = frame.resize(self.frame_size[::-1], Image.BILINEAR)  # type: ignore[attr-defined]
+            target = (self.frame_size[1], self.frame_size[0])  # PIL expects (W, H)
+            if frame.size != target:
+                frame = frame.resize(target, Image.BILINEAR)  # type: ignore[attr-defined]
+
+        # Canonical bytes: encode once, decode for inference, reuse for every upload/backup.
+        # Guarantees model and stored media see byte-identical input.
+        buf = io.BytesIO()
+        frame.save(buf, format="JPEG", quality=self.jpeg_quality)
+        encoded_bytes = buf.getvalue()
+        buf.seek(0)
+        frame = Image.open(buf).convert("RGB")
 
         # Heartbeat
         if len(self.api_client) > 0 and isinstance(cam_id, str):
@@ -198,9 +208,7 @@ class Engine(Predictor):
                 self._states[cam_key]["last_image_sent"] = time.time()
                 ip = cam_id.split("_")[0]
                 if ip in self.api_client:
-                    stream = io.BytesIO()
-                    frame.save(stream, format="JPEG", quality=self.jpeg_quality)
-                    response = self.api_client[ip].update_last_image(stream.getvalue())
+                    response = self.api_client[ip].update_last_image(encoded_bytes)
                     logger.info(response.text)
 
         # Update occlusion masks from API
@@ -243,10 +251,10 @@ class Engine(Predictor):
                 preds = np.reshape(preds, (-1, 5))
 
         logger.info(f"pred for {cam_key} : {preds}")
-        conf = self._update_states(frame, preds, cam_key)
+        conf = self._update_states(frame, preds, cam_key, encoded_bytes=encoded_bytes)
 
         if self.save_captured_frames:
-            self._local_backup(frame, cam_id, is_alert=False)
+            self._local_backup(frame, cam_id, is_alert=False, encoded_bytes=encoded_bytes)
 
         # Log analysis result
         device_str = f"Camera '{cam_id}' - " if isinstance(cam_id, str) else ""
@@ -256,20 +264,30 @@ class Engine(Predictor):
         # Alert
         if conf > self.conf_thresh and len(self.api_client) > 0 and isinstance(cam_id, str):
             # Save the alert in cache to avoid connection issues
-            for idx, (frame, preds, bboxes, ts, is_staged) in enumerate(self._states[cam_key]["last_predictions"]):
+            for idx, (frame_, preds_, bboxes, ts, is_staged, jpeg_bytes) in enumerate(
+                self._states[cam_key]["last_predictions"]
+            ):
                 if not is_staged:
-                    self._stage_alert(frame, cam_id, ts, bboxes)
+                    self._stage_alert(frame_, cam_id, ts, bboxes, jpeg_bytes)
                     self._states[cam_key]["last_predictions"][idx] = (
-                        frame,
-                        preds,
+                        frame_,
+                        preds_,
                         bboxes,
                         ts,
                         True,
+                        jpeg_bytes,
                     )
 
         return float(conf)
 
-    def _stage_alert(self, frame: Image.Image, cam_id: str, ts: int, bboxes: list) -> None:
+    def _stage_alert(
+        self,
+        frame: Image.Image,
+        cam_id: str,
+        ts: int,
+        bboxes: list,
+        jpeg_bytes: Optional[bytes] = None,
+    ) -> None:
         # Store information in the queue
         self._alerts.append({
             "frame": frame,
@@ -278,6 +296,7 @@ class Engine(Predictor):
             "media_id": None,
             "alert_id": None,
             "bboxes": bboxes,
+            "jpeg_bytes": jpeg_bytes,
         })
 
     def fill_empty_bboxes(self) -> None:
@@ -310,7 +329,11 @@ class Engine(Predictor):
 
                 # Save alert on device
                 if self.save_detections_frames:
-                    self._local_backup(frame_info["frame"], cam_id)
+                    self._local_backup(
+                        frame_info["frame"],
+                        cam_id,
+                        encoded_bytes=frame_info.get("jpeg_bytes"),
+                    )
 
                 try:
                     # Detection creation
@@ -319,12 +342,16 @@ class Engine(Predictor):
                         logger.warning(f"Camera '{cam_id}' - skipping alert with empty bboxes")
                         self._alerts.popleft()
                         continue
-                    stream = io.BytesIO()
-                    frame_info["frame"].save(stream, format="JPEG", quality=self.jpeg_quality)
+                    jpeg_bytes = frame_info.get("jpeg_bytes")
+                    if jpeg_bytes is None:
+                        # Fallback for cached alerts staged before this version
+                        stream = io.BytesIO()
+                        frame_info["frame"].save(stream, format="JPEG", quality=self.jpeg_quality)
+                        jpeg_bytes = stream.getvalue()
                     bboxes = [tuple(bboxe) for bboxe in bboxes]
                     _, pose_id = self.cam_creds[cam_id]
                     ip = cam_id.split("_")[0]
-                    response = self.api_client[ip].create_detection(stream.getvalue(), bboxes, pose_id)
+                    response = self.api_client[ip].create_detection(jpeg_bytes, bboxes, pose_id)
 
                     try:
                         response.json()["id"]
@@ -335,20 +362,27 @@ class Engine(Predictor):
                     # Clear
                     self._alerts.popleft()
                     logger.info(f"Camera '{cam_id}' - alert sent")
-                    stream.seek(0)  # "Rewind" the stream to the beginning so we can read its content
 
                 except (KeyError, RequestsConnectionError, ValueError) as e:
                     logger.error(f"Camera '{cam_id}' - unable to upload cache")
                     logger.error(e)
                     break
 
-    def _local_backup(self, img: Image.Image, cam_id: Optional[str], is_alert: bool = True) -> None:
+    def _local_backup(
+        self,
+        img: Image.Image,
+        cam_id: Optional[str],
+        is_alert: bool = True,
+        encoded_bytes: Optional[bytes] = None,
+    ) -> None:
         """Save image on device
 
         Args:
             img (Image.Image): Image to save
             cam_id (str): camera id (ip address)
             is_alert (bool): is the frame an alert ?
+            encoded_bytes: pre-encoded JPEG bytes — written verbatim when provided so the
+                on-disk file is byte-identical to what was scored / uploaded.
         """
         folder = "alerts" if is_alert else "save"
         backup_cache = self._cache.joinpath(f"backup/{folder}/")
@@ -356,7 +390,10 @@ class Engine(Predictor):
         backup_cache = backup_cache.joinpath(f"{time.strftime('%Y%m%d')}/{cam_id}")
         backup_cache.mkdir(parents=True, exist_ok=True)
         file = backup_cache.joinpath(f"{time.strftime('%Y%m%d-%H%M%S')}.jpg")
-        img.save(file)
+        if encoded_bytes is not None:
+            file.write_bytes(encoded_bytes)
+        else:
+            img.save(file)
 
     def _clean_local_backup(self, backup_cache: Path) -> None:
         """Clean local backup when it's bigger than _backup_size MB


### PR DESCRIPTION
  Investigation into why predictions on the Pi don't match what we get when we pull
  the same image back from the API and re-score it surfaced two issues:

  1. The current model is **highly sensitive to JPEG compression and resize choice**.
     On a 3000-image sample, the same 720p frame scored as raw PIL vs. round-tripped
     through JPEG q=80 (which is what the API stores) loses **~21% of alertable
     detections** with conf drops up to 0.33.
  2. The engine pipeline has a byte-level mismatch: the model runs on the in-memory
     PIL frame (no JPEG), but the API only ever sees the JPEG-q80-encoded version.
     Re-scoring the API media therefore produces different predictions than the Pi
     ever computed.

  A new model with JPEG-quality augmentation in training is in progress:
  https://github.com/pyronear/pyro-train/actions/runs/24598391010/job/71932816841

  That should remove most of the model-side sensitivity. While we wait for it, this
  PR fixes the byte-level mismatch so the current pipeline is at least
  **reproducible end to end** — the same prediction the Pi got can be recomputed by
  anyone who downloads the image from the alert API.

  ## Change

  In `Engine.predict()`, after the resize, JPEG-encode the frame **once** at
  `self.jpeg_quality`, then decode it back. The decoded PIL is what the model scores;
  the encoded bytes are what get uploaded everywhere (heartbeat, alert media, local
  backup). New contract:

  bytes the model sees  ==  bytes uploaded to alert API  ==  bytes on local backup

  `jpeg_quality` stays at **80** for now to match the current training distribution.
  Once the new model lands we can re-evaluate (likely move to q=90 or higher).

  To make this work the encoded bytes are threaded through:
  `Predictor._update_states` → `last_predictions` deque → `Engine._stage_alert` →
  `_alerts` dict → `_process_alerts`. `_local_backup` writes the bytes verbatim when
  provided.

  ## Side-effects

  - `last_predictions` tuple grew from 5 to 6 elements (added `encoded_bytes` field).
    All existing tests use index-based access in `[0]`–`[4]` so nothing breaks.
  - `Predictor._update_states` gained an optional `encoded_bytes=None` kwarg —
    backwards compatible for any standalone `pyro_predictor` user.
  - Same-size resize is now short-circuited in both `Predictor.predict()` and
    `Engine.predict()` (no functional change — verified PIL bilinear at the same
    size is bit-identical — just avoids wasted work when a caller already hands in
    a 720p frame).