### PR TITLE
bump model to plucky-pelican v7.1.0, nb_consecutive_frames=5

### DIFF
--- a/pyro-predictor/pyro_predictor/vision.py
+++ b/pyro-predictor/pyro_predictor/vision.py
@@ -19,7 +19,7 @@ from .utils import box_iou, letterbox, nms, xywh2xyxy
 
 __all__ = ["Classifier"]
 
-MODEL_REPO_ID = "pyronear/yolo11s_nimble-narwhal_v6.0.0"
+MODEL_REPO_ID = "pyronear/yolo11s_plucky-pelican_v7.1.0"
 MODEL_NAME = "ncnn_cpu.tar.gz"
 
 logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=logging.INFO, force=True)

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -81,7 +81,7 @@ class Engine(Predictor):
         max_bbox_size: float = 0.4,
         api_url: Optional[str] = None,
         cam_creds: Optional[Dict[str, Dict[str, str]]] = None,
-        nb_consecutive_frames: int = 7,
+        nb_consecutive_frames: int = 5,
         frame_size: Optional[Tuple[int, int]] = None,
         cache_backup_period: int = 60,
         frame_saving_period: Optional[int] = None,

--- a/src/run.py
+++ b/src/run.py
@@ -119,7 +119,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--nb-consecutive_frames",
         type=int,
-        default=7,
+        default=5,
         help="Number of consecutive frames to combine for prediction",
     )
     parser.add_argument(


### PR DESCRIPTION
Bumps the detection model to pyronear/yolo11s_plucky-pelican_v7.1.0, trained in pyronear/pyro-train#22.                                                                                                    
                                                                                                                                                                                                             
  The new model was trained to be resilient to JPEG compression, resizing, and (hopefully) camera changes. The previous nimble-narwhal model was way too sensitive to those factors — small encoding or      
  hardware variations produced very different scores.                                                                                                                                                        
                                                                                                                                                                                                             
  Also lowers nb_consecutive_frames from 7 to 5, since the new model is more stable frame-to-frame.  