### PR TITLE
pin markdown-links actions to tagged versions

### DIFF
--- a/.github/workflows/markdown-links-config.json
+++ b/.github/workflows/markdown-links-config.json
@@ -3,5 +3,9 @@
         {
           "pattern": "^https://github.com/YOUR_USERNAME"
         }
-    ]
+    ],
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206, 429]
 }

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -10,7 +10,7 @@ jobs:
   markdown-link-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: gaurav-nelson/github-action-markdown-link-check@master
+    - uses: actions/checkout@v4
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: '.github/workflows/markdown-links-config.json'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Whatever the way you wish to contribute to the project, please respect the [code
 
 This project uses the following integrations to ensure proper codebase maintenance:
 
-- [Github Worklow](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) - run jobs for package build and coverage
+- [Github Worklow](https://docs.github.com/en/actions/using-workflows/about-workflows) - run jobs for package build and coverage
 - [Codacy](https://www.codacy.com/) - analyzes commits for code quality
 - [Codecov](https://codecov.io/) - reports back coverage results
 


### PR DESCRIPTION
Fix dead ling 

```
Current runner version: '2.333.1'
Runner Image Provisioner
Operating System
Runner Image
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'actions/checkout@master' (SHA:0c366fd6a839edf440554fa01a7085ccba70ac98)
Download action repository 'gaurav-nelson/github-action-markdown-link-check@master' (SHA:0524e79d8d7d1606112722dd7a3b5f5ce367de3e)
Error: An action could not be found at the URI 'https://api.github.com/repos/gaurav-nelson/github-action-markdown-link-check/tarball/0524e79d8d7d1606112722dd7a3b5f5ce367de3e' (1440:202A1C:6653:7A9D:69E642E0)
Error: Failed to download archive 'https://api.github.com/repos/gaurav-nelson/github-action-markdown-link-check/tarball/0524e79d8d7d1606112722dd7a3b5f5ce367de3e' after 1 attempts.
```