### PR TITLE
feed uncompressed frame to model

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -191,13 +191,10 @@ class Engine(Predictor):
             if frame.size != target:
                 frame = frame.resize(target, Image.BILINEAR)  # type: ignore[attr-defined]
 
-        # Canonical bytes: encode once, decode for inference, reuse for every upload/backup.
-        # Guarantees model and stored media see byte-identical input.
+        # Encode once for API uploads and on-disk backup; feed the uncompressed frame to the model.
         buf = io.BytesIO()
         frame.save(buf, format="JPEG", quality=self.jpeg_quality)
         encoded_bytes = buf.getvalue()
-        buf.seek(0)
-        frame = Image.open(buf).convert("RGB")
 
         # Heartbeat
         if len(self.api_client) > 0 and isinstance(cam_id, str):


### PR DESCRIPTION
  plucky-pelican v7.1.0 is compression-resistant, so the JPEG encode/decode round-trip before inference is no longer needed. The frame is now passed to the model uncompressed. JPEG bytes are still produced for API uploads and on-disk backups