### PR TITLE
fix: replace single-IP ping with multi-method internet check

### DIFF
--- a/watchdog/pi_zero/watchdog.py
+++ b/watchdog/pi_zero/watchdog.py
@@ -59,7 +59,8 @@ CAM_IPS: list[str] = [ip.strip() for ip in _cam_ips_raw.split(",") if ip.strip()
 _INTERNET_HTTP_URLS = [
     "https://clients3.google.com/generate_204",
     "https://connectivitycheck.gstatic.com/generate_204",
-    "https://example.com",
+    "http://cp.cloudflare.com",
+    "www.msftconnecttest.com/connecttest.txt"
 ]
 _INTERNET_PING_IPS = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
 

--- a/watchdog/pi_zero/watchdog.py
+++ b/watchdog/pi_zero/watchdog.py
@@ -56,7 +56,12 @@ CAM_IPS: list[str] = [ip.strip() for ip in _cam_ips_raw.split(",") if ip.strip()
     "192.168.1.11",
     "192.168.1.12",
 ]
-INTERNET_IP = "1.1.1.1"
+_INTERNET_HTTP_URLS = [
+    "https://clients3.google.com/generate_204",
+    "https://connectivitycheck.gstatic.com/generate_204",
+    "https://example.com",
+]
+_INTERNET_PING_IPS = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
 
 PING_COUNT = 2
 TIMEOUT = 2  # seconds, used for ping and HTTP timeout
@@ -133,6 +138,25 @@ def ping_host(ip: str, count: int = PING_COUNT, timeout: int = TIMEOUT) -> bool:
         return True
     except subprocess.CalledProcessError:
         return False
+
+
+def internet_check_ok() -> bool:
+    for url in _INTERNET_HTTP_URLS:
+        try:
+            with urlopen(url, timeout=TIMEOUT) as resp:
+                if resp.status in (200, 204):
+                    logging.info("Internet HTTP check OK: %s", url)
+                    return True
+        except Exception:
+            pass
+
+    for ip in _INTERNET_PING_IPS:
+        if ping_host(ip, count=1, timeout=TIMEOUT):
+            logging.info("Internet ping fallback OK: %s", ip)
+            return True
+
+    logging.warning("Internet connectivity FAILED")
+    return False
 
 
 def http_health_ok(url: str) -> bool:
@@ -253,8 +277,8 @@ def main() -> None:
 
     reboot_12v = False
 
-    internet_ok = ping_host(INTERNET_IP, count=1, timeout=TIMEOUT)
-    internet_fails = update_fail_counter(internet_ok, FAIL_INTERNET_FILE, f"Internet {INTERNET_IP}")
+    internet_ok = internet_check_ok()
+    internet_fails = update_fail_counter(internet_ok, FAIL_INTERNET_FILE, "Internet")
     if internet_fails >= MAX_FAILS:
         reboot_12v = True
 

--- a/watchdog/pi_zero/watchdog.py
+++ b/watchdog/pi_zero/watchdog.py
@@ -60,7 +60,7 @@ _INTERNET_HTTP_URLS = [
     "https://clients3.google.com/generate_204",
     "https://connectivitycheck.gstatic.com/generate_204",
     "http://cp.cloudflare.com",
-    "www.msftconnecttest.com/connecttest.txt"
+    "www.msftconnecttest.com/connecttest.txt",
 ]
 _INTERNET_PING_IPS = ["1.1.1.1", "8.8.8.8", "9.9.9.9"]
 
@@ -148,7 +148,7 @@ def internet_check_ok() -> bool:
                 if resp.status in (200, 204):
                     logging.info("Internet HTTP check OK: %s", url)
                     return True
-        except Exception:
+        except Exception:  # noqa: S110
             pass
 
     for ip in _INTERNET_PING_IPS:


### PR DESCRIPTION
# Pitch
ICMP ping to public IPs (1.1.1.1, 8.8.8.8) can be blocked on mobile/4G networks even when real internet access works. This caused false-positive internet failures on some watchdog CRON run

## Modifications

Replaces ping_host(INTERNET_IP) with internet_check_ok() which tries lightweight HTTP/HTTPS probes first (generate_204 endpoints) and falls back to pinging multiple IPs only if all HTTP checks fail. No new dependencies — uses stdlib urllib.request.

------

### Hypothesis

ICMP — Internet Control Message Protocol is a low-level network protocol used for diagnostics (ping, traceroute, "host unreachable" messages). It operates below TCP/UDP — no ports, just raw IP packets with a type field.

Why operators might block it:

- DDoS mitigation — ICMP flood attacks are trivial to launch, so many carriers simply drop inbound/outbound ICMP at their edge to protect infrastructure.
- Traffic prioritization — on constrained 4G links, operators deprioritize or discard "non-revenue" control traffic; ICMP is the easiest thing to drop without breaking real applications.
- Firewalling policy — some operators run CGNAT + stateful firewalls that only track TCP/UDP sessions; ICMP has no session concept so it gets dropped by default.
- Prevent network mapping — blocking ICMP makes it harder for outsiders to probe the operator's internal topology.

HTTP/HTTPS traffic on port 443 is virtually never blocked because that would break the entire web — which is why it's a more reliable signal for "internet is actually working."