### PR TITLE
refactor(predictor): simplify _update_states, drop anchor logic

### DIFF
--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -113,7 +113,7 @@ class Predictor:
             sums = (overlap * pool[:, 4]).sum(axis=1)
             combine_conf = sums / nb
 
-            valid_mask = (counts >= (nb // 2)) & (combine_conf > effective_thresh)
+            valid_mask = (counts >= ((nb + 1) // 2)) & (combine_conf > effective_thresh)
             valid_candidates = candidates[valid_mask]
             valid_conf = combine_conf[valid_mask]
 
@@ -133,6 +133,8 @@ class Predictor:
                         x1, y1, x2, y2 = preds[p_idx, :4]
                         rows.append([x1, y1, x2, y2, float(valid_conf[c_idx])])
                     output_predictions = np.round(np.array(rows, dtype=np.float64), 3).astype(np.float64)
+                    # Keep top-5 by confidence to bound the API payload.
+                    output_predictions = output_predictions[output_predictions[:, 4].argsort()[::-1]][:5]
 
         self._states[cam_key]["last_predictions"].append((
             frame,

--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -132,7 +132,7 @@ class Predictor:
                         c_idx = int(matched_cand[p_idx])
                         x1, y1, x2, y2 = preds[p_idx, :4]
                         rows.append([x1, y1, x2, y2, float(valid_conf[c_idx])])
-                    output_predictions = np.round(np.array(rows, dtype=np.float64), 3)
+                    output_predictions = np.round(np.array(rows, dtype=np.float64), 3).astype(np.float64)
 
         self._states[cam_key]["last_predictions"].append((
             frame,

--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -71,8 +71,9 @@ class Predictor:
                 self._states[cam_id] = self._new_state()
 
     def _new_state(self) -> Dict[str, Any]:
+        # Window holds nb_consecutive_frames - 1 past frames; pool = current + window = nb total.
         return {
-            "last_predictions": deque(maxlen=self.nb_consecutive_frames),
+            "last_predictions": deque(maxlen=self.nb_consecutive_frames - 1),
             "ongoing": False,
         }
 

--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -85,6 +85,9 @@ class Predictor:
         encoded_bytes: Optional[bytes] = None,
     ) -> float:
         nb = self.nb_consecutive_frames
+        prev_ongoing = self._states[cam_key]["ongoing"]
+        # Hysteresis: once alerting, relax the threshold so the alert keeps emitting frames.
+        effective_thresh = self.conf_thresh * 0.8 if prev_ongoing else self.conf_thresh
 
         # Pool = current preds + every past frame's raw preds in the sliding window.
         pool = np.zeros((0, 5), dtype=np.float64)
@@ -105,7 +108,7 @@ class Predictor:
             sums = (overlap * pool[:, 4]).sum(axis=1)
             combine_conf = sums / nb
 
-            valid_mask = (counts >= (nb // 2)) & (combine_conf > self.conf_thresh)
+            valid_mask = (counts >= (nb // 2)) & (combine_conf > effective_thresh)
             valid_candidates = candidates[valid_mask]
             valid_conf = combine_conf[valid_mask]
 
@@ -134,7 +137,7 @@ class Predictor:
             False,
             encoded_bytes,
         ))
-        self._states[cam_key]["ongoing"] = conf > self.conf_thresh
+        self._states[cam_key]["ongoing"] = conf > effective_thresh
         return conf
 
     def predict(

--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -55,6 +55,8 @@ class Predictor:
         verbose: bool = True,
         **kwargs: Any,
     ) -> None:
+        if nb_consecutive_frames < 2:
+            raise ValueError(f"nb_consecutive_frames must be >= 2, got {nb_consecutive_frames}")
         self.verbose = verbose
         self.model = Classifier(
             model_path=model_path, conf=model_conf_thresh, max_bbox_size=max_bbox_size, verbose=verbose, **kwargs
@@ -71,9 +73,10 @@ class Predictor:
                 self._states[cam_id] = self._new_state()
 
     def _new_state(self) -> Dict[str, Any]:
-        # Window holds nb_consecutive_frames - 1 past frames; pool = current + window = nb total.
+        # Deque keeps nb past frames so staging can replay them; only the last nb-1
+        # are used to score, keeping pool = current + nb-1 past = nb total.
         return {
-            "last_predictions": deque(maxlen=self.nb_consecutive_frames - 1),
+            "last_predictions": deque(maxlen=self.nb_consecutive_frames),
             "ongoing": False,
         }
 
@@ -89,10 +92,12 @@ class Predictor:
         # Hysteresis: once alerting, relax the threshold so the alert keeps emitting frames.
         effective_thresh = self.conf_thresh * 0.8 if prev_ongoing else self.conf_thresh
 
-        # Pool = current preds + every past frame's raw preds in the sliding window.
+        # Pool = current preds + last (nb - 1) past frames' raw preds.
         pool = np.zeros((0, 5), dtype=np.float64)
         pool = np.concatenate([pool, preds])
-        for _, box, _, _, _, _ in self._states[cam_key]["last_predictions"]:
+        history = self._states[cam_key]["last_predictions"]
+        recent_past = list(history)[-(nb - 1):] if nb > 1 else []
+        for _, box, _, _, _, _ in recent_past:
             if box.shape[0] > 0:
                 pool = np.concatenate([pool, box])
 

--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -104,7 +104,7 @@ class Predictor:
             sums = (overlap * pool[:, 4]).sum(axis=1)
             combine_conf = sums / nb
 
-            valid_mask = counts >= (nb // 2)
+            valid_mask = (counts >= (nb // 2)) & (combine_conf > self.conf_thresh)
             valid_candidates = candidates[valid_mask]
             valid_conf = combine_conf[valid_mask]
 

--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -96,7 +96,7 @@ class Predictor:
         pool = np.zeros((0, 5), dtype=np.float64)
         pool = np.concatenate([pool, preds])
         history = self._states[cam_key]["last_predictions"]
-        recent_past = list(history)[-(nb - 1):] if nb > 1 else []
+        recent_past = list(history)[-(nb - 1) :] if nb > 1 else []
         for _, box, _, _, _, _ in recent_past:
             if box.shape[0] > 0:
                 pool = np.concatenate([pool, box])

--- a/pyro-predictor/pyro_predictor/predictor.py
+++ b/pyro-predictor/pyro_predictor/predictor.py
@@ -74,9 +74,6 @@ class Predictor:
         return {
             "last_predictions": deque(maxlen=self.nb_consecutive_frames),
             "ongoing": False,
-            "anchor_bbox": None,
-            "anchor_ts": None,
-            "miss_count": 0,
         }
 
     def _update_states(
@@ -86,90 +83,57 @@ class Predictor:
         cam_key: str,
         encoded_bytes: Optional[bytes] = None,
     ) -> float:
-        prev_ongoing = self._states[cam_key]["ongoing"]
+        nb = self.nb_consecutive_frames
 
-        conf_th = self.conf_thresh * self.nb_consecutive_frames
-        if prev_ongoing:
-            conf_th *= 0.8
-
-        boxes = np.zeros((0, 5), dtype=np.float64)
-        boxes = np.concatenate([boxes, preds])
+        # Pool = current preds + every past frame's raw preds in the sliding window.
+        pool = np.zeros((0, 5), dtype=np.float64)
+        pool = np.concatenate([pool, preds])
         for _, box, _, _, _, _ in self._states[cam_key]["last_predictions"]:
             if box.shape[0] > 0:
-                boxes = np.concatenate([boxes, box])
+                pool = np.concatenate([pool, box])
 
         conf = 0.0
         output_predictions: npt.NDArray[np.float64] = np.zeros((0, 5), dtype=np.float64)
 
-        if boxes.shape[0]:
-            best_boxes = nms(boxes)
-            detections = boxes[boxes[:, -1] > self.conf_thresh, :]
-            ious_detections = box_iou(best_boxes[:, :4], detections[:, :4])
-            strong_detection = np.sum(ious_detections > 0, axis=0) >= int(self.nb_consecutive_frames / 2)
-            best_boxes = best_boxes[strong_detection, :]
+        if pool.shape[0]:
+            candidates = nms(pool)
+            # box_iou(A, B) returns shape (len(B), len(A)); call with (pool, candidates) -> (n_cand, n_pool)
+            ious_pool = box_iou(pool[:, :4], candidates[:, :4])
+            overlap = ious_pool > 0  # (n_cand, n_pool)
+            counts = overlap.sum(axis=1)
+            sums = (overlap * pool[:, 4]).sum(axis=1)
+            combine_conf = sums / nb
 
-            if best_boxes.shape[0]:
-                ious = box_iou(best_boxes[:, :4], boxes[:, :4])
-                best_boxes_scores = np.array([sum(boxes[iou > 0, 4]) for iou in ious.T])
-                combine_predictions = best_boxes[best_boxes_scores > conf_th, :]
-                if len(best_boxes_scores) > 0:
-                    conf = np.max(best_boxes_scores) / (self.nb_consecutive_frames + 1)
+            valid_mask = counts >= (nb // 2)
+            valid_candidates = candidates[valid_mask]
+            valid_conf = combine_conf[valid_mask]
 
-                if combine_predictions.shape[0] > 0:
-                    ious = box_iou(combine_predictions[:, :4], preds[:, :4])
-                    iou_match = np.array([np.max(iou) > 0 for iou in ious], dtype=bool)
-                    matched_preds = preds[iou_match, :]
-                    if matched_preds.ndim == 1:
-                        matched_preds = matched_preds[np.newaxis, :]
-                    output_predictions = matched_preds.astype(np.float64)
+            if valid_conf.size > 0:
+                conf = float(valid_conf.max())
 
-        # no zero confidence fabrication before ongoing
-        # if empty and we were already ongoing, reuse anchor but set conf to 0
-        if output_predictions.shape[0] == 0:
-            anchor = self._states[cam_key]["anchor_bbox"]
-            if prev_ongoing and anchor is not None:
-                output_predictions = anchor.copy()
-                output_predictions[:, -1] = 0.0  # filled during ongoing, confidence forced to 0
-            else:
-                output_predictions = np.empty((0, 5), dtype=np.float64)  # stays empty for backfill later
-        else:
-            # refresh anchor during ongoing with light smoothing
-            if prev_ongoing:
-                best_idx = int(np.argmax(output_predictions[:, 4]))
-                best = output_predictions[best_idx : best_idx + 1]
-                anchor = self._states[cam_key]["anchor_bbox"]
-                if anchor is None:
-                    self._states[cam_key]["anchor_bbox"] = best.copy()
-                else:
-                    alpha = 0.3
-                    self._states[cam_key]["anchor_bbox"] = alpha * best + (1.0 - alpha) * anchor
-                self._states[cam_key]["miss_count"] = 0
-
-        output_predictions = np.round(output_predictions, 3)
-        output_predictions = output_predictions[:5, :]
-        if output_predictions.size > 0:
-            output_predictions = np.atleast_2d(output_predictions)
+            if valid_candidates.shape[0] and preds.shape[0]:
+                # ious_preds shape: (n_valid, n_preds)
+                ious_preds = box_iou(preds[:, :4], valid_candidates[:, :4])
+                overlap_preds = ious_preds > 0
+                has_match = overlap_preds.any(axis=0)
+                if has_match.any():
+                    matched_cand = overlap_preds.argmax(axis=0)
+                    rows = []
+                    for p_idx in np.where(has_match)[0]:
+                        c_idx = int(matched_cand[p_idx])
+                        x1, y1, x2, y2 = preds[p_idx, :4]
+                        rows.append([x1, y1, x2, y2, float(valid_conf[c_idx])])
+                    output_predictions = np.round(np.array(rows, dtype=np.float64), 3)
 
         self._states[cam_key]["last_predictions"].append((
             frame,
             preds,
-            output_predictions.tolist(),  # [] if empty
+            output_predictions.tolist(),
             datetime.now(timezone.utc).isoformat(),
             False,
             encoded_bytes,
         ))
-
-        new_ongoing = conf > self.conf_thresh
-        if prev_ongoing and not new_ongoing:
-            self._states[cam_key]["anchor_bbox"] = None
-            self._states[cam_key]["anchor_ts"] = None
-            self._states[cam_key]["miss_count"] = 0
-        elif not prev_ongoing and new_ongoing:
-            if output_predictions.size > 0:
-                self._states[cam_key]["anchor_bbox"] = output_predictions.copy()
-                self._states[cam_key]["miss_count"] = 0
-
-        self._states[cam_key]["ongoing"] = new_ongoing
+        self._states[cam_key]["ongoing"] = conf > self.conf_thresh
         return conf
 
     def predict(

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Never, Optional, Tuple
 import numpy as np
 from PIL import Image
 from pyro_predictor import Predictor
+from pyro_predictor.utils import box_iou
 from pyroclient import client
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import RequestException
@@ -277,11 +278,16 @@ class Engine(Predictor):
 
         # Alert
         if conf > self.conf_thresh and len(self.api_client) > 0 and isinstance(cam_id, str):
-            # Save the alert in cache to avoid connection issues
+            # Collect every bbox the predictor emitted across the window; treat these as
+            # tracked locations and backfill missing per-frame bboxes from raw preds with conf=0.
+            tracked = [b[:4] for _, _, bbs, _, _, _ in self._states[cam_key]["last_predictions"] for b in bbs]
+            tracked_arr = np.array(tracked, dtype=np.float64) if tracked else np.empty((0, 4))
+
             for idx, (frame_, preds_, bboxes, ts, is_staged, jpeg_bytes) in enumerate(
                 self._states[cam_key]["last_predictions"]
             ):
                 if not is_staged:
+                    bboxes = self._backfill_bboxes(bboxes, preds_, tracked_arr)
                     self._stage_alert(frame_, cam_id, ts, bboxes, jpeg_bytes)
                     self._states[cam_key]["last_predictions"][idx] = (
                         frame_,
@@ -293,6 +299,23 @@ class Engine(Predictor):
                     )
 
         return float(conf)
+
+    @staticmethod
+    def _backfill_bboxes(bboxes: list, preds: np.ndarray, tracked: np.ndarray) -> list:
+        """For each raw pred overlapping a tracked location but not yet in bboxes, append it with conf=0."""
+        if tracked.shape[0] == 0 or preds.shape[0] == 0:
+            return list(bboxes)
+        existing = np.array([b[:4] for b in bboxes], dtype=np.float64) if bboxes else np.empty((0, 4))
+        ious_tracked = box_iou(preds[:, :4], tracked)  # shape (n_tracked, n_preds)
+        hits_tracked = (ious_tracked > 0).any(axis=0)  # per pred
+        out = list(bboxes)
+        for p_idx in np.where(hits_tracked)[0]:
+            box = preds[p_idx, :4]
+            if existing.shape[0] and (box_iou(box[None, :], existing) > 0).any():
+                continue
+            out.append([float(box[0]), float(box[1]), float(box[2]), float(box[3]), 0.0])
+            existing = np.vstack([existing, box[None, :]])
+        return out
 
     def _stage_alert(
         self,

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -276,8 +276,8 @@ class Engine(Predictor):
         pred_str = "Wildfire detected" if conf > self.conf_thresh else "No wildfire"
         logger.info(f"{device_str}{pred_str} (confidence: {conf:.2%})")
 
-        # Alert
-        if conf > self.conf_thresh and len(self.api_client) > 0 and isinstance(cam_id, str):
+        # Alert (use ongoing so hysteresis-relaxed threshold keeps staging frames during a dip)
+        if self._states[cam_key]["ongoing"] and len(self.api_client) > 0 and isinstance(cam_id, str):
             # Collect every bbox the predictor emitted across the window; treat these as
             # tracked locations and backfill missing per-frame bboxes from raw preds with conf=0.
             tracked = [b[:4] for _, _, bbs, _, _, _ in self._states[cam_key]["last_predictions"] for b in bbs]

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -337,23 +337,11 @@ class Engine(Predictor):
         })
 
     def fill_empty_bboxes(self) -> None:
-        cam_id_to_indices: Dict[str, list[int]] = {}
-        for i, alert in enumerate(self._alerts):
-            cam_id_to_indices.setdefault(alert["cam_id"], []).append(i)
-
-        for indices in cam_id_to_indices.values():
-            non_empty_indices = [i for i in indices if self._alerts[i]["bboxes"]]
-            if not non_empty_indices:
-                continue
-            for i in indices:
-                if not self._alerts[i]["bboxes"]:
-                    closest_index = min(non_empty_indices, key=lambda x: abs(x - i))
-                    src = np.array(self._alerts[closest_index]["bboxes"], dtype=float)
-                    if src.size == 0:
-                        continue
-                    filled = src.copy()
-                    filled[:, -1] = 0.0  # force confidence to 0 for duplicated boxes
-                    self._alerts[i]["bboxes"] = [tuple(row) for row in filled.tolist()]
+        # Stamp a tiny placeholder bbox at conf=0 on any alert with none,
+        # so the upload guard always sees a non-empty payload.
+        for alert in self._alerts:
+            if not alert["bboxes"]:
+                alert["bboxes"] = [(0.0, 0.0, 0.0001, 0.0001, 0.0)]
 
     def _process_alerts(self) -> None:
         if self.cam_creds is not None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -66,14 +66,14 @@ def test_engine_offline(tmpdir_factory, mock_wildfire_image, mock_forest_image):
     out = engine.predict(mock_wildfire_image)
     assert isinstance(out, float)
     assert 0 <= out <= 1
-    assert len(engine._states["-1"]["last_predictions"]) == 4
+    assert len(engine._states["-1"]["last_predictions"]) == 3
     assert engine._states["-1"]["ongoing"]
     assert isinstance(engine._states["-1"]["last_predictions"][0][0], Image.Image)
-    assert engine._states["-1"]["last_predictions"][3][1].shape[0] > 0
-    assert engine._states["-1"]["last_predictions"][3][1].shape[1] == 5
+    assert engine._states["-1"]["last_predictions"][-1][1].shape[0] > 0
+    assert engine._states["-1"]["last_predictions"][-1][1].shape[1] == 5
     assert len(engine._states["-1"]["last_predictions"][-1][2][0]) == 5
-    assert engine._states["-1"]["last_predictions"][3][3] < datetime.now().isoformat()
-    assert engine._states["-1"]["last_predictions"][3][4] is False
+    assert engine._states["-1"]["last_predictions"][-1][3] < datetime.now().isoformat()
+    assert engine._states["-1"]["last_predictions"][-1][4] is False
 
 
 def create_dummy_onnx_model(model_path):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -66,7 +66,7 @@ def test_engine_offline(tmpdir_factory, mock_wildfire_image, mock_forest_image):
     out = engine.predict(mock_wildfire_image)
     assert isinstance(out, float)
     assert 0 <= out <= 1
-    assert len(engine._states["-1"]["last_predictions"]) == 3
+    assert len(engine._states["-1"]["last_predictions"]) == 4
     assert engine._states["-1"]["ongoing"]
     assert isinstance(engine._states["-1"]["last_predictions"][0][0], Image.Image)
     assert engine._states["-1"]["last_predictions"][-1][1].shape[0] > 0

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -218,8 +218,8 @@ def test_process_alerts_respects_save_detections_flag(tmp_path, save_detections_
 
 
 def test_fill_empty_bboxes(tmp_path):
-    """fill_empty_bboxes should replace empty-bbox alerts with the closest non-empty
-    sibling from the same cam_id, with confidence forced to 0."""
+    """fill_empty_bboxes stamps a placeholder bbox at conf=0 on any empty alert
+    and leaves non-empty alerts untouched."""
     engine = Engine(cache_folder=str(tmp_path))
 
     img = Image.new("RGB", (8, 8))
@@ -237,24 +237,16 @@ def test_fill_empty_bboxes(tmp_path):
 
     engine.fill_empty_bboxes()
 
-    # Every alert is now non-empty
     assert all(alert["bboxes"] for alert in engine._alerts)
-    # The previously-empty frame (index 3) was filled from the closest sibling
-    # (index 2 or 4 — both equidistant; min() picks the lower index)
-    filled = engine._alerts[3]["bboxes"]
-    assert len(filled) == 1
-    # Geometry copied from the source
-    assert filled[0][:4] == pytest.approx((0.436, 0.609, 0.44, 0.62))
-    # Confidence forced to 0
-    assert filled[0][4] == 0.0
-    # Other frames are untouched
+    # Previously-empty frame gets the placeholder bbox at conf=0
+    assert engine._alerts[3]["bboxes"] == [(0.0, 0.0, 0.0001, 0.0001, 0.0)]
+    # Non-empty frames untouched
     assert engine._alerts[0]["bboxes"][0][4] == pytest.approx(0.089)
     assert engine._alerts[5]["bboxes"][0][4] == pytest.approx(0.389)
 
 
 def test_fill_empty_bboxes_all_empty_for_cam(tmp_path):
-    """If a cam_id has only empty-bbox alerts, fill_empty_bboxes leaves them empty
-    so the upload guard in _process_alerts can drop them."""
+    """Even when every alert for a cam_id is empty, each one gets the placeholder."""
     engine = Engine(cache_folder=str(tmp_path))
 
     img = Image.new("RGB", (8, 8))
@@ -263,7 +255,7 @@ def test_fill_empty_bboxes_all_empty_for_cam(tmp_path):
 
     engine.fill_empty_bboxes()
 
-    assert all(not alert["bboxes"] for alert in engine._alerts)
+    assert all(alert["bboxes"] == [(0.0, 0.0, 0.0001, 0.0001, 0.0)] for alert in engine._alerts)
 
 
 def test_engine_occlusion(tmpdir_factory, mock_wildfire_stream, mock_wildfire_image):


### PR DESCRIPTION
## Summary
- Replace strong-detection vote + EMA-anchor scheme with a single candidate-vote rule.
  Pool = current preds + last (nb_consecutive_frames - 1) past frames. NMS → candidates.
  Per candidate: count overlapping pool boxes and sum their confs. Valid if
  count >= nb/2 AND sums/nb > conf_thresh. Per-frame output = current preds
  overlapping any valid candidate, with conf replaced by combine_conf.
- Drop anchor_bbox / anchor_ts / miss_count, EMA smoothing, fill-on-miss.
- Keep a 0.8x hysteresis on conf_thresh while ongoing.
- Engine: gate alert staging on state["ongoing"] so hysteresis actually flows.
- Engine: backfill missing per-frame bboxes from raw preds whenever they
  overlap a bbox the predictor emitted elsewhere in the window (conf=0).
- Engine: fill_empty_bboxes stamps a (0,0,0.0001,0.0001,0) placeholder on any
  alert that is still empty so the API always receives a payload.

## Worked example — FP seq pyronear-sdis-07_brison_127_2024-03-06T06-45-24

Box format: [x1, y1, x2, y2, conf] (normalized).

```
frame  0  idle   model     [0.5615, 0.5482, 0.5732, 0.5629, 0.252], [0.7654, 0.6202, 0.7756, 0.6367, 0.084]
                 predictor []
frame  1  idle   model     [0.5618, 0.5482, 0.5730, 0.5629, 0.103]
                 predictor []
frame  2  idle   model     [0.7661, 0.6207, 0.7759, 0.6380, 0.065]
                 predictor []
frame  3  idle   model     [0.7651, 0.6202, 0.7759, 0.6367, 0.124]
                 predictor []
frame  4  idle   model     [0.5640, 0.5482, 0.5728, 0.5629, 0.162], [0.7656, 0.6215, 0.7764, 0.6372, 0.084]
                 predictor []
frame  5  idle   model     [0.7654, 0.6198, 0.7756, 0.6372, 0.302], [0.5635, 0.5477, 0.5732, 0.5616, 0.054]
                 predictor []
frame  6  idle   model     [0.7654, 0.6198, 0.7756, 0.6372, 0.252]
                 predictor []
frame  7  idle   model     [0.5637, 0.5482, 0.5730, 0.5629, 0.106], [0.7656, 0.6194, 0.7764, 0.6376, 0.102]
                 predictor []
frame  8  idle   model     [0.7654, 0.6202, 0.7756, 0.6367, 0.175], [0.5635, 0.5477, 0.5732, 0.5616, 0.075]
                 predictor []
frame  9  ALERT  model     [0.7649, 0.6198, 0.7761, 0.6372, 0.304], [0.5642, 0.5477, 0.5745, 0.5616, 0.068]
                 predictor [0.7650, 0.6200, 0.7760, 0.6370, 0.176]   <- new: combine_conf
                                                                        old: 0.304 (raw model conf)
```

Right cluster crosses conf_thresh=0.15 at frame 9 after appearing in >= 4 of
the 8 frames in the pool. Left cluster never qualifies.

## API payload at first alert (frame 9) — before vs after this PR

Window held by the deque at staging: frames 2..9 (8 frames).

**Before this PR:**

The old predictor emitted nothing for frames 2-8 (strong-detection gate hadn't
fired yet), then on frame 9 emitted the raw model bbox with its raw conf.
`fill_empty_bboxes` then copied frame 9's bbox into every empty sibling with
conf=0 — so every backfilled frame uploaded the **same identical** bbox.

```
frame 2  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.000]   <- sibling copy from frame 9
frame 3  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.000]   <- sibling copy
frame 4  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.000]   <- sibling copy
frame 5  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.000]   <- sibling copy
frame 6  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.000]   <- sibling copy
frame 7  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.000]   <- sibling copy
frame 8  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.000]   <- sibling copy
frame 9  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.304]   <- raw model conf
```

**After this PR:**

The predictor emits the combined sliding-window conf at frame 9. Engine
backfill uses each frame's *own* raw model coordinates (matched to the
tracked right cluster) rather than copying frame 9's box.

```
frame 2  API: [0.7661, 0.6207, 0.7759, 0.6380, 0.000]   <- backfilled, raw coords frame 2
frame 3  API: [0.7651, 0.6202, 0.7759, 0.6367, 0.000]   <- backfilled, raw coords frame 3
frame 4  API: [0.7656, 0.6215, 0.7764, 0.6372, 0.000]   <- backfilled, raw coords frame 4
frame 5  API: [0.7654, 0.6198, 0.7756, 0.6372, 0.000]   <- backfilled, raw coords frame 5
frame 6  API: [0.7654, 0.6198, 0.7756, 0.6372, 0.000]   <- backfilled, raw coords frame 6
frame 7  API: [0.7656, 0.6194, 0.7764, 0.6376, 0.000]   <- backfilled, raw coords frame 7
frame 8  API: [0.7654, 0.6202, 0.7756, 0.6367, 0.000]   <- backfilled, raw coords frame 8
frame 9  API: [0.7650, 0.6200, 0.7760, 0.6370, 0.176]   <- combine_conf
```

Two concrete differences:
1. **Backfilled bboxes follow per-frame model jitter** (~1-2 px) instead of
   being 7 identical copies of frame 9's box.
2. **Alert frame conf is the smoothed window aggregate (0.176)** instead of
   the raw model conf for that one frame (0.304), matching the value used
   by the alert-trigger decision.