### PR TITLE
chore: bump model to rapid-raccoon v8.1.0

### DIFF
--- a/pyro-predictor/pyro_predictor/vision.py
+++ b/pyro-predictor/pyro_predictor/vision.py
@@ -20,7 +20,7 @@ from .utils import box_iou, letterbox, nms, xywh2xyxy
 
 __all__ = ["Classifier"]
 
-MODEL_REPO_ID = "pyronear/yolo11s_quick-quokka_v8.0.0"
+MODEL_REPO_ID = "pyronear/yolo11s_rapid-raccoon_v8.1.0"
 MODEL_NAME = "ncnn_cpu.tar.gz"
 MODEL_SLUG = MODEL_REPO_ID.split("/", 1)[1]
 MODEL_CACHE_SUBDIR = "models"


### PR DESCRIPTION
after fixing annotaitons in dataset retrained done here : https://github.com/pyronear/pyro-train/pull/24



- Bump `MODEL_REPO_ID` from `pyronear/yolo11s_quick-quokka_v8.0.0` to `pyronear/yolo11s_rapid-raccoon_v8.1.0`
- No parameter changes (keeps `nb_consecutive_frames=6`, `conf_thresh=0.25` from v8.0.0 bump)