### PR TITLE
feat(engine): send one detection crop per bbox

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -351,7 +351,8 @@ class Engine(Predictor):
     def _encode_detection_crops(self, frame: Image.Image, bboxes: list) -> Optional[list[bytes]]:
         """Crop the original frame around each bbox and encode one 224x224 JPEG per bbox to upload."""
         # Placeholder-only alerts carry no real detection, so they upload no crops.
-        if not bboxes or list(bboxes) == [PLACEHOLDER_BBOX]:
+        # Compare element-wise as tuples so list-form bboxes are handled too.
+        if not bboxes or all(tuple(bbox) == PLACEHOLDER_BBOX for bbox in bboxes):
             return None
         img_w, img_h = frame.size
         crops: list[bytes] = []

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -24,6 +24,9 @@ from requests.models import Response
 
 __all__ = ["Engine"]
 
+# Degenerate bbox stamped on alerts with no detection so the upload payload is never empty.
+PLACEHOLDER_BBOX = (0.0, 0.0, 0.0001, 0.0001, 0.0)
+
 logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
 
@@ -364,6 +367,16 @@ class Engine(Predictor):
             crop.save(buf, format="JPEG", quality=100, subsampling=0, optimize=True)
         return buf.getvalue()
 
+    def _encode_detection_crops(self, frame: Image.Image, bboxes: list) -> Optional[list[bytes]]:
+        """Encode one crop per bbox, aligned by index, as required by the detection API."""
+        if not bboxes or list(bboxes) == [PLACEHOLDER_BBOX]:
+            return None
+        crops = [self._encode_detection_crop(frame, [bbox]) for bbox in bboxes]
+        # The API requires exactly one crop per bbox; drop crops entirely if any encode failed.
+        if not all(crops):
+            return None
+        return [crop for crop in crops if crop is not None]
+
     @staticmethod
     def _backfill_bboxes(bboxes: list, preds: np.ndarray, tracked: np.ndarray) -> list:
         """For each raw pred overlapping a tracked location but not yet in bboxes, append it with conf=0."""
@@ -405,7 +418,7 @@ class Engine(Predictor):
         # so the upload guard always sees a non-empty payload.
         for alert in self._alerts:
             if not alert["bboxes"]:
-                alert["bboxes"] = [(0.0, 0.0, 0.0001, 0.0001, 0.0)]
+                alert["bboxes"] = [PLACEHOLDER_BBOX]
 
     def _process_alerts(self) -> None:
         if self.cam_creds is not None:
@@ -438,10 +451,10 @@ class Engine(Predictor):
                         frame_info["frame"].save(stream, format="JPEG", quality=self.jpeg_quality)
                         jpeg_bytes = stream.getvalue()
                     bboxes = [tuple(bboxe) for bboxe in bboxes]
-                    crop_bytes = self._encode_detection_crop(frame_info["frame"], bboxes)
+                    crops = self._encode_detection_crops(frame_info["frame"], bboxes)
                     _, pose_id = self.cam_creds[cam_id]
                     ip = cam_id.split("_")[0]
-                    response = self.api_client[ip].create_detection(jpeg_bytes, bboxes, pose_id, crop=crop_bytes)
+                    response = self.api_client[ip].create_detection(jpeg_bytes, bboxes, pose_id, crops=crops)
 
                     try:
                         response.json()["id"]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -291,6 +291,21 @@ def test_encode_detection_crops_placeholder_returns_none(tmp_path):
 
     assert engine._encode_detection_crops(frame, [PLACEHOLDER_BBOX]) is None
     assert engine._encode_detection_crops(frame, []) is None
+    # List-form placeholder (not a tuple) must still be treated as placeholder-only
+    assert engine._encode_detection_crops(frame, [list(PLACEHOLDER_BBOX)]) is None
+
+
+def test_encode_detection_crops_mixed_placeholder_and_real_bbox(tmp_path):
+    """A placeholder mixed with a real bbox still yields one crop per bbox, not None."""
+    engine = Engine(cache_folder=str(tmp_path))
+    frame = Image.new("RGB", (640, 480))
+    bboxes = [PLACEHOLDER_BBOX, (0.5, 0.5, 0.7, 0.7, 0.6)]
+
+    crops = engine._encode_detection_crops(frame, bboxes)
+
+    assert crops is not None
+    assert len(crops) == len(bboxes)
+    assert all(isinstance(c, bytes) for c in crops)
 
 
 def _build_engine_with_fake_client(tmp_path):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,3 +1,4 @@
+import io
 import os
 import tempfile
 import time
@@ -10,7 +11,7 @@ import pytest
 from dotenv import load_dotenv
 from PIL import Image
 
-from pyroengine.engine import Engine
+from pyroengine.engine import PLACEHOLDER_BBOX, Engine
 
 
 def test_engine_offline(tmpdir_factory, mock_wildfire_image, mock_forest_image):
@@ -256,6 +257,67 @@ def test_fill_empty_bboxes_all_empty_for_cam(tmp_path):
     engine.fill_empty_bboxes()
 
     assert all(alert["bboxes"] == [(0.0, 0.0, 0.0001, 0.0001, 0.0)] for alert in engine._alerts)
+
+
+def test_encode_detection_crops_one_per_bbox(tmp_path):
+    engine = Engine(cache_folder=str(tmp_path))
+    frame = Image.new("RGB", (640, 480))
+    bboxes = [(0.1, 0.1, 0.2, 0.2, 0.9), (0.5, 0.5, 0.7, 0.7, 0.6)]
+
+    crops = engine._encode_detection_crops(frame, bboxes)
+
+    assert isinstance(crops, list)
+    assert len(crops) == len(bboxes)
+    for crop_bytes, bbox in zip(crops, bboxes, strict=True):
+        crop = Image.open(io.BytesIO(crop_bytes))
+        assert crop.size == (224, 224)
+        # Each crop matches its own bbox region, not a merged one
+        expected_box = engine._compute_crop_box([bbox], 640, 480, padding=0.20)
+        expected = frame.crop(expected_box).resize((224, 224), Image.LANCZOS)
+        assert crop.size == expected.size
+
+
+def test_encode_detection_crops_placeholder_returns_none(tmp_path):
+    engine = Engine(cache_folder=str(tmp_path))
+    frame = Image.new("RGB", (640, 480))
+
+    assert engine._encode_detection_crops(frame, [PLACEHOLDER_BBOX]) is None
+    assert engine._encode_detection_crops(frame, []) is None
+
+
+def _build_engine_with_fake_client(tmp_path):
+    cam_id = "169.254.7.3_3"
+    engine = Engine(cache_folder=str(tmp_path))
+    engine.cam_creds = {cam_id: ("dummy_token", 3)}
+    fake_client = MagicMock()
+    fake_client.create_detection.return_value = MagicMock(json=MagicMock(return_value={"id": 1}))
+    engine.api_client = {"169.254.7.3": fake_client}
+    return engine, fake_client, cam_id
+
+
+def test_process_alerts_sends_one_crop_per_bbox(tmp_path):
+    engine, fake_client, cam_id = _build_engine_with_fake_client(tmp_path)
+    bboxes = [(0.1, 0.1, 0.2, 0.2, 0.9), (0.5, 0.5, 0.7, 0.7, 0.6)]
+    engine._stage_alert(Image.new("RGB", (640, 480)), cam_id, int(time.time()), bboxes=bboxes)
+
+    engine._process_alerts()
+
+    assert fake_client.create_detection.call_count == 1
+    crops = fake_client.create_detection.call_args.kwargs["crops"]
+    assert len(crops) == 2
+    assert all(isinstance(c, bytes) for c in crops)
+    assert len(engine._alerts) == 0
+
+
+def test_process_alerts_placeholder_bbox_sends_no_crop(tmp_path):
+    engine, fake_client, cam_id = _build_engine_with_fake_client(tmp_path)
+    engine._stage_alert(Image.new("RGB", (640, 480)), cam_id, int(time.time()), bboxes=[])
+
+    engine._process_alerts()
+
+    assert fake_client.create_detection.call_count == 1
+    assert fake_client.create_detection.call_args.kwargs["crops"] is None
+    assert len(engine._alerts) == 0
 
 
 def _build_engine_with_pose_stub(tmp_path, init_clock):


### PR DESCRIPTION
- Adapts to pyronear/pyro-api#616 (merged): `Client.create_detection` now takes `crops` (one crop per bbox, aligned by index) instead of a single `crop`.
- Each bbox gets its own square 224x224 crop (same padding/encoding logic as before); placeholder-only alerts send no crop.
- Adds tests for per-bbox encoding, placeholder handling, and the `crops` kwarg in `_process_alerts`.
- `develop` was merged in: it independently landed the same per-bbox refactor, so this branch now only adds the `PLACEHOLDER_BBOX` constant and the placeholder-only → `crops=None` guard on top of it.
- The pyroclient pin in `requirements-git.txt` (and `uv.lock`) is bumped to the pyro-api#616 merge commit `2f4a08a`, so the new `crops=` kwarg resolves and CI passes.
