### PR TITLE
fix: send one crop per bbox to match new detections API

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -345,24 +345,27 @@ class Engine(Predictor):
 
         return round(left), round(top), round(right), round(bottom)
 
-    def _encode_detection_crop(self, frame: Image.Image, bboxes: list) -> Optional[bytes]:
-        """Crop the original frame around bboxes and encode the 224x224 JPEG to upload."""
+    def _encode_detection_crops(self, frame: Image.Image, bboxes: list) -> Optional[list[bytes]]:
+        """Crop the original frame around each bbox and encode one 224x224 JPEG per bbox to upload."""
         if not bboxes:
             return None
         img_w, img_h = frame.size
-        box = self._compute_crop_box(bboxes, img_w, img_h, padding=0.20)
-        crop = frame.crop(box)
-        crop_w, crop_h = crop.size
-        downscaling = crop_w > 224 or crop_h > 224
-        if (crop_w, crop_h) != (224, 224):
-            crop = crop.resize((224, 224), Image.LANCZOS)  # type: ignore[attr-defined]
-        buf = io.BytesIO()
-        if downscaling:
-            crop.save(buf, format="JPEG", quality=95)
-        else:
-            # Crop was at or below 224 — preserve detail with no chroma subsampling.
-            crop.save(buf, format="JPEG", quality=100, subsampling=0, optimize=True)
-        return buf.getvalue()
+        crops: list[bytes] = []
+        for bbox in bboxes:
+            box = self._compute_crop_box([bbox], img_w, img_h, padding=0.20)
+            crop = frame.crop(box)
+            crop_w, crop_h = crop.size
+            downscaling = crop_w > 224 or crop_h > 224
+            if (crop_w, crop_h) != (224, 224):
+                crop = crop.resize((224, 224), Image.LANCZOS)  # type: ignore[attr-defined]
+            buf = io.BytesIO()
+            if downscaling:
+                crop.save(buf, format="JPEG", quality=95)
+            else:
+                # Crop was at or below 224 — preserve detail with no chroma subsampling.
+                crop.save(buf, format="JPEG", quality=100, subsampling=0, optimize=True)
+            crops.append(buf.getvalue())
+        return crops
 
     @staticmethod
     def _backfill_bboxes(bboxes: list, preds: np.ndarray, tracked: np.ndarray) -> list:
@@ -438,10 +441,10 @@ class Engine(Predictor):
                         frame_info["frame"].save(stream, format="JPEG", quality=self.jpeg_quality)
                         jpeg_bytes = stream.getvalue()
                     bboxes = [tuple(bboxe) for bboxe in bboxes]
-                    crop_bytes = self._encode_detection_crop(frame_info["frame"], bboxes)
+                    crops = self._encode_detection_crops(frame_info["frame"], bboxes)
                     _, pose_id = self.cam_creds[cam_id]
                     ip = cam_id.split("_")[0]
-                    response = self.api_client[ip].create_detection(jpeg_bytes, bboxes, pose_id, crop=crop_bytes)
+                    response = self.api_client[ip].create_detection(jpeg_bytes, bboxes, pose_id, crops=crops)
 
                     try:
                         response.json()["id"]

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,1 +1,1 @@
-pyroclient @ git+https://github.com/pyronear/pyro-api.git@02328388b7b2ebab538bfb78ec6f5c52a1dfe67c#subdirectory=client
+pyroclient @ git+https://github.com/pyronear/pyro-api.git@2f4a08ad39b313982051f178b11070d6f9b1165f#subdirectory=client

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,1 +1,1 @@
-pyroclient @ git+https://github.com/pyronear/pyro-api.git@938d0d60eee79b05cbe404e04df3e9d559baa690#subdirectory=client
+pyroclient @ git+https://github.com/pyronear/pyro-api.git@02328388b7b2ebab538bfb78ec6f5c52a1dfe67c#subdirectory=client

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,3 +1,4 @@
+import io
 import os
 import tempfile
 import time
@@ -256,6 +257,32 @@ def test_fill_empty_bboxes_all_empty_for_cam(tmp_path):
     engine.fill_empty_bboxes()
 
     assert all(alert["bboxes"] == [(0.0, 0.0, 0.0001, 0.0001, 0.0)] for alert in engine._alerts)
+
+
+def test_encode_detection_crops_one_per_bbox(tmp_path):
+    """_encode_detection_crops returns one 224x224 JPEG per bbox, aligned by index."""
+    engine = Engine(cache_folder=str(tmp_path))
+
+    frame = Image.new("RGB", (1280, 720))
+    # Paint the first bbox region red so the two crops have distinct content
+    frame.paste((255, 0, 0), (0, 0, 250, 250))
+    bboxes = [
+        (0.05, 0.05, 0.15, 0.15, 0.9),
+        (0.8, 0.7, 0.95, 0.9, 0.5),
+    ]
+
+    crops = engine._encode_detection_crops(frame, bboxes)
+
+    assert crops is not None
+    assert len(crops) == len(bboxes)
+    for crop_bytes in crops:
+        crop = Image.open(io.BytesIO(crop_bytes))
+        assert crop.format == "JPEG"
+        assert crop.size == (224, 224)
+    # Distant bboxes must yield different crops, not one shared global crop
+    assert crops[0] != crops[1]
+
+    assert engine._encode_detection_crops(frame, []) is None
 
 
 def _build_engine_with_pose_stub(tmp_path, init_clock):

--- a/uv.lock
+++ b/uv.lock
@@ -1158,7 +1158,7 @@ requires-dist = [
 [[package]]
 name = "pyroclient"
 version = "0.2.0.dev0"
-source = { git = "https://github.com/pyronear/pyro-api.git?subdirectory=client&rev=main#02328388b7b2ebab538bfb78ec6f5c52a1dfe67c" }
+source = { git = "https://github.com/pyronear/pyro-api.git?subdirectory=client&rev=main#2f4a08ad39b313982051f178b11070d6f9b1165f" }
 dependencies = [
     { name = "requests" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1158,7 +1158,7 @@ requires-dist = [
 [[package]]
 name = "pyroclient"
 version = "0.2.0.dev0"
-source = { git = "https://github.com/pyronear/pyro-api.git?subdirectory=client&rev=main#938d0d60eee79b05cbe404e04df3e9d559baa690" }
+source = { git = "https://github.com/pyronear/pyro-api.git?subdirectory=client&rev=main#02328388b7b2ebab538bfb78ec6f5c52a1dfe67c" }
 dependencies = [
     { name = "requests" },
 ]


### PR DESCRIPTION
- pyro-api#616 changed `Client.create_detection` to take `crops: list[bytes]`, one crop per bbox, replacing the single `crop` argument.
- The engine now encodes one 224x224 crop per bbox (same padding/square/clamp logic, applied per box) instead of one crop covering all boxes.
- Pins pyroclient to pyro-api main (post-#616 merge).