### PR TITLE
feat(camera): add generic REST/JSON snapshot camera adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ CAM_PWD=my_dummy_pwd
 # MediaMTX server IP (used by pyro-camera-api to build SRT output URLs)
 MEDIAMTX_SERVER_IP=1.2.3.4
 
+# Tokens for "rest" adapter cameras. Reference them from credentials.json as
+# ${VAR}, e.g. {"headers": {"Authorization": "Bearer ${VIGILANT_TOKEN}"}}.
+# VIGILANT_TOKEN=my_dummy_token
+
 # Docker image tag for both services (defaults to "latest" if unset)
 # Set to a specific version for pinned deployments, e.g. PYRO_ENGINE_VERSION=1.2.0
 PYRO_ENGINE_VERSION=latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 PyroEngine is a wildfire detection system for edge devices (Raspberry Pi, etc.). It has two main packages:
 
 - **`pyroengine/`** — Core detection engine: runs YOLO model inference on camera images, manages alert states, communicates with the PyroNear API.
-- **`pyro_camera_api/`** — FastAPI service: unified REST interface for controlling heterogeneous cameras (Reolink, Linovision/Hikvision, RTSP, HTTP URL).
+- **`pyro_camera_api/`** — FastAPI service: unified REST interface for controlling heterogeneous cameras (Reolink, Linovision/Hikvision, RTSP, HTTP URL, generic REST/JSON snapshot API).
 
 These two services run as separate Docker containers and communicate over localhost (host network mode). The engine calls the camera API to capture frames and manage PTZ patrols.
 
@@ -44,7 +44,8 @@ pytest tests/test_engine.py -v
 ### Camera API
 
 - Entry point: `pyro_camera_api/pyro_camera_api/main.py` (FastAPI + lifespan)
-- Camera adapters in `camera/adapters/`: `reolink.py`, `linovision.py`, `rtsp.py`, `url.py`, `mock.py` — all inherit from abstract bases in `camera/base.py`
+- Camera adapters in `camera/adapters/`: `reolink.py`, `linovision.py`, `rtsp.py`, `url.py`, `rest.py`, `mock.py` — all inherit from abstract bases in `camera/base.py`
+  - `rest.py` (`RestSnapshotCamera`, adapter `"rest"`/`"api"`) is a config-driven HTTP snapshot adapter for endpoints that need custom auth headers or return the image wrapped in JSON (base64 or nested URL), e.g. vigilant.cat. Header/URL values may reference env vars via `${VAR}`.
 - `camera/registry.py` tracks live camera instances and background threads
 - Background patrol loops run in `camera/patrol.py`
 - Routes under `api/`: cameras, control (PTZ), focus, patrol, stream, health

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,10 @@ services:
       context: ./pyro_camera_api
     image: pyronear/pyro-camera-api:${PYRO_ENGINE_VERSION:-latest}
     container_name: pyro-camera-api
+    # Load .env so tokens referenced as ${VAR} by "rest" adapter cameras
+    # (in credentials.json) are available inside the container.
+    env_file:
+      - .env
     environment:
       CAM_USER: ${CAM_USER}
       CAM_PWD: ${CAM_PWD}

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/__init__.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/__init__.py
@@ -1,6 +1,7 @@
 # pyro_camera_api/camera/adapters/__init__.py
 from .reolink import ReolinkCamera
+from .rest import RestSnapshotCamera
 from .rtsp import RTSPCamera
 from .url import URLCamera
 
-__all__ = ["RTSPCamera", "ReolinkCamera", "URLCamera"]
+__all__ = ["RTSPCamera", "ReolinkCamera", "RestSnapshotCamera", "URLCamera"]

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/rest.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/rest.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2022-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+from __future__ import annotations
+
+import base64
+import logging
+import re
+from io import BytesIO
+from typing import Any, Dict, Optional
+
+import requests
+from PIL import Image
+
+from pyro_camera_api.camera.base import BaseCamera
+
+logger = logging.getLogger(__name__)
+
+# Header names whose values must never be logged in clear.
+_SENSITIVE_HEADERS = {"authorization", "x-api-key", "api-key", "apikey", "token"}
+# Query parameters whose values must never be logged in clear.
+_SENSITIVE_QUERY = re.compile(r"(token|access_token|api_?key|pwd|password)=([^&]+)", re.IGNORECASE)
+
+
+class RestSnapshotCamera(BaseCamera):
+    """Generic HTTP/REST snapshot camera (capture only).
+
+    Fetches a single frame from an HTTP endpoint that may need custom
+    authentication headers and may wrap the image inside a JSON envelope,
+    which :class:`URLCamera` cannot handle. One adapter serves many providers
+    through configuration:
+
+    - ``response="image"``: the body is the raw image bytes.
+    - ``response="json"``: the body is JSON; ``json_path`` (dot-separated)
+      points to the payload field, decoded either as base64 (``encoding="base64"``)
+      or as a nested image URL to re-fetch (``encoding="url"``).
+
+    Example (vigilant.cat): ``response="json"``, ``json_path="data"``,
+    ``encoding="base64"`` with an ``Authorization: Bearer <token>`` header.
+    """
+
+    def __init__(
+        self,
+        camera_id: str,
+        url: str,
+        headers: Optional[Dict[str, str]] = None,
+        response: str = "image",
+        json_path: Optional[str] = None,
+        encoding: str = "base64",
+        timeout: int = 15,
+        retries: int = 2,
+        cam_type: str = "static",
+    ) -> None:
+        super().__init__(camera_id=camera_id, cam_type=cam_type)
+        self.url = url
+        self.headers = headers or {}
+        self.response = response
+        self.json_path = json_path
+        self.encoding = encoding
+        self.timeout = timeout
+        self.retries = retries
+        self._session = requests.Session()
+
+    @staticmethod
+    def _redact_headers(headers: Dict[str, str]) -> Dict[str, str]:
+        """Mask sensitive header values for safe logging."""
+        return {k: ("***" if k.lower() in _SENSITIVE_HEADERS else v) for k, v in headers.items()}
+
+    @staticmethod
+    def _redact_url(url: str) -> str:
+        """Mask credential-like query parameters for safe logging."""
+        return _SENSITIVE_QUERY.sub(r"\1=***", url)
+
+    @staticmethod
+    def _dig(payload: Any, path: str) -> Any:
+        """Navigate a dot-separated path into a nested JSON structure."""
+        node = payload
+        for key in path.split("."):
+            node = node[key]
+        return node
+
+    def _decode_bytes(self, resp: requests.Response) -> bytes:
+        """Turn the HTTP response into raw image bytes according to the config."""
+        if self.response == "image":
+            return resp.content
+
+        if self.response == "json":
+            if not self.json_path:
+                raise ValueError("response='json' requires 'json_path'")
+            field = self._dig(resp.json(), self.json_path)
+
+            if self.encoding == "base64":
+                if isinstance(field, str) and field.startswith("data:"):
+                    # Strip a data URI prefix such as "data:image/jpeg;base64,".
+                    field = field.split(",", 1)[1]
+                return base64.b64decode(field)
+
+            if self.encoding == "url":
+                sub = self._session.get(field, headers=self.headers, timeout=self.timeout)
+                sub.raise_for_status()
+                return sub.content
+
+            raise ValueError(f"unknown encoding '{self.encoding}'")
+
+        raise ValueError(f"unknown response mode '{self.response}'")
+
+    def capture(self, patrol_id: Optional[int] = None) -> Optional[Image.Image]:
+        """Fetch a single snapshot and return it as a Pillow Image, or None on failure."""
+        _ = patrol_id  # kept for API compatibility with PTZ adapters
+        attempts = self.retries + 1
+        redacted_url = self._redact_url(self.url)
+        redacted_headers = self._redact_headers(self.headers)
+
+        for attempt in range(1, attempts + 1):
+            try:
+                resp = self._session.get(self.url, headers=self.headers, timeout=self.timeout)
+                resp.raise_for_status()
+                img = Image.open(BytesIO(self._decode_bytes(resp))).convert("RGB")
+                logger.info("REST capture OK from %s, size=%s", redacted_url, img.size)
+                return img
+            except Exception as exc:
+                logger.warning(
+                    "REST capture failed for %s (attempt %d/%d), headers=%r, %s",
+                    redacted_url,
+                    attempt,
+                    attempts,
+                    redacted_headers,
+                    exc,
+                )
+
+        logger.error("REST capture giving up for %s after %d attempts", redacted_url, attempts)
+        return None

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/rest.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/rest.py
@@ -11,6 +11,7 @@ import logging
 import re
 from io import BytesIO
 from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 import requests
 from PIL import Image
@@ -74,6 +75,16 @@ class RestSnapshotCamera(BaseCamera):
         """Mask credential-like query parameters for safe logging."""
         return _SENSITIVE_QUERY.sub(r"\1=***", url)
 
+    def _safe_headers(self) -> Dict[str, str]:
+        """Return headers with sensitive values removed (for cross-origin fetches)."""
+        return {k: v for k, v in self.headers.items() if k.lower() not in _SENSITIVE_HEADERS}
+
+    @staticmethod
+    def _same_origin(a: str, b: str) -> bool:
+        """True when both URLs share scheme, host and port."""
+        pa, pb = urlparse(a), urlparse(b)
+        return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
+
     @staticmethod
     def _dig(payload: Any, path: str) -> Any:
         """Navigate a dot-separated path into a nested JSON structure."""
@@ -99,7 +110,15 @@ class RestSnapshotCamera(BaseCamera):
                 return base64.b64decode(field)
 
             if self.encoding == "url":
-                sub = self._session.get(field, headers=self.headers, timeout=self.timeout)
+                # The JSON endpoint controls this URL, so only forward the auth
+                # headers when it stays on the same origin; otherwise strip them
+                # to avoid disclosing the token to an arbitrary host (e.g. a CDN).
+                if self._same_origin(self.url, field):
+                    headers = self.headers
+                else:
+                    headers = self._safe_headers()
+                    logger.info("REST nested fetch is cross-origin, dropping sensitive headers")
+                sub = self._session.get(field, headers=headers, timeout=self.timeout)
                 sub.raise_for_status()
                 return sub.content
 

--- a/pyro_camera_api/pyro_camera_api/camera/registry.py
+++ b/pyro_camera_api/pyro_camera_api/camera/registry.py
@@ -7,6 +7,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
 import threading
 from collections import defaultdict
 from typing import Dict, Optional
@@ -14,10 +16,34 @@ from typing import Dict, Optional
 from pyro_camera_api.camera.adapters.linovision import LinovisionCamera
 from pyro_camera_api.camera.adapters.mock import MockCamera
 from pyro_camera_api.camera.adapters.reolink import ReolinkCamera
+from pyro_camera_api.camera.adapters.rest import RestSnapshotCamera
 from pyro_camera_api.camera.adapters.rtsp import RTSPCamera
 from pyro_camera_api.camera.adapters.url import URLCamera
 from pyro_camera_api.camera.base import BaseCamera
 from pyro_camera_api.core.config import CAM_PWD, CAM_USER, RAW_CONFIG
+
+# Placeholder for referencing environment variables from credentials.json,
+# e.g. {"headers": {"Authorization": "Bearer ${VIGILANT_TOKEN}"}}. Keeps
+# secrets in .env instead of the committed/mounted config file.
+_ENV_PLACEHOLDER = re.compile(r"\$\{([^}]+)\}")
+
+
+def _resolve_env(value: str) -> str:
+    """Replace ${VAR} placeholders using environment variables.
+
+    Raises KeyError on the first unset variable so a misconfigured camera fails
+    fast at registration instead of sending broken credentials at capture time.
+    """
+
+    def repl(match: re.Match[str]) -> str:
+        name = match.group(1)
+        env_val = os.environ.get(name)
+        if env_val is None:
+            raise KeyError(name)
+        return env_val
+
+    return _ENV_PLACEHOLDER.sub(repl, value)
+
 
 logger = logging.getLogger("CameraRegistry")
 logger.setLevel(logging.INFO)
@@ -49,7 +75,8 @@ def build_camera_object(key: str, conf: dict) -> Optional[BaseCamera]:
     Build the appropriate camera object based on configuration.
 
     Expected keys in conf:
-      adapter:  "reolink-823S2", "reolink-823A16", "linovision", "rtsp", "url", "mock".
+      adapter:  "reolink-823S2", "reolink-823A16", "linovision", "rtsp", "url",
+                "rest" (alias "api"), "mock".
                 Generic "reolink" is still accepted by the registry (it builds
                 a ReolinkCamera from any string containing "reolink"), but the
                 PTZ routes require a specific model for the calibrated speed
@@ -57,7 +84,9 @@ def build_camera_object(key: str, conf: dict) -> Optional[BaseCamera]:
       type:     "ptz" or "static"
       ip_address
       rtsp_url (if adapter=rtsp)
-      url (if adapter=url or adapter=mock)
+      url (if adapter=url, rest or mock)
+      headers, response, json_path, encoding, timeout, retries (if adapter=rest).
+        Header/URL values may reference environment variables as ${VAR}.
       poses, azimuths, focus_position (PTZ adapters)
     """
     adapter = conf.get("adapter", "").lower()
@@ -130,6 +159,37 @@ def build_camera_object(key: str, conf: dict) -> Optional[BaseCamera]:
             cam_type="static",
         )
         logger.info("Registered URL snapshot camera %s", key)
+        return cam
+
+    # Generic REST / HTTP-API snapshot camera (capture only).
+    # Handles endpoints needing custom auth headers and/or a JSON-wrapped image
+    # (base64 or nested URL), e.g. vigilant.cat.
+    if adapter in ("rest", "api"):
+        snapshot_url = conf.get("url")
+        if not snapshot_url:
+            logger.error("Camera %s declared as REST adapter but missing 'url'", key)
+            return None
+
+        headers = conf.get("headers", {}) or {}
+        try:
+            snapshot_url = _resolve_env(snapshot_url)
+            headers = {k: _resolve_env(str(v)) for k, v in headers.items()}
+        except KeyError as exc:
+            logger.error("Camera %s references unset environment variable %s", key, exc)
+            return None
+
+        cam = RestSnapshotCamera(
+            camera_id=key,
+            url=snapshot_url,
+            headers=headers,
+            response=conf.get("response", "image"),
+            json_path=conf.get("json_path"),
+            encoding=conf.get("encoding", "base64"),
+            timeout=conf.get("timeout", 15),
+            retries=conf.get("retries", 2),
+            cam_type="static",
+        )
+        logger.info("Registered REST snapshot camera %s", key)
         return cam
 
     # Mock camera adapter for tests and demos

--- a/pyro_camera_api/tests/test_rest_snapshot.py
+++ b/pyro_camera_api/tests/test_rest_snapshot.py
@@ -77,6 +77,41 @@ def test_capture_json_url_refetch():
     assert get.call_count == 2
 
 
+def test_url_refetch_same_origin_forwards_auth_header():
+    cam = RestSnapshotCamera(
+        "cam",
+        "https://host/meta",
+        headers={"Authorization": "Bearer secret"},
+        response="json",
+        json_path="url",
+        encoding="url",
+    )
+    meta = _response(json_body={"url": "https://host/frames/1.jpg"})  # same origin
+    image = _response(content=_jpeg_bytes())
+    with patch.object(cam._session, "get", side_effect=[meta, image]) as get:
+        cam.capture()
+    _, kwargs = get.call_args  # second (nested) call
+    assert kwargs["headers"].get("Authorization") == "Bearer secret"
+
+
+def test_url_refetch_cross_origin_strips_auth_header():
+    cam = RestSnapshotCamera(
+        "cam",
+        "https://host/meta",
+        headers={"Authorization": "Bearer secret", "User-Agent": "pyro"},
+        response="json",
+        json_path="url",
+        encoding="url",
+    )
+    meta = _response(json_body={"url": "https://cdn.other.com/1.jpg"})  # different origin
+    image = _response(content=_jpeg_bytes())
+    with patch.object(cam._session, "get", side_effect=[meta, image]) as get:
+        cam.capture()
+    _, kwargs = get.call_args
+    assert "Authorization" not in kwargs["headers"]
+    assert kwargs["headers"].get("User-Agent") == "pyro"  # non-sensitive header kept
+
+
 def test_capture_returns_none_on_http_error():
     cam = RestSnapshotCamera("cam", "https://host/snap", retries=0)
     with patch.object(cam._session, "get", return_value=_response(status=500, content=b"<html>error</html>")):

--- a/pyro_camera_api/tests/test_rest_snapshot.py
+++ b/pyro_camera_api/tests/test_rest_snapshot.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2022-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+import base64
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+from PIL import Image
+
+from pyro_camera_api.camera.adapters.rest import RestSnapshotCamera
+
+
+def _jpeg_bytes(color=(10, 20, 30)):
+    buf = BytesIO()
+    Image.new("RGB", (8, 8), color).save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _response(status=200, content=b"", json_body=None):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.content = content
+    if json_body is not None:
+        resp.json.return_value = json_body
+    if status >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_capture_raw_image():
+    cam = RestSnapshotCamera("cam", "https://host/snap", response="image")
+    with patch.object(cam._session, "get", return_value=_response(content=_jpeg_bytes())) as get:
+        img = cam.capture()
+    assert isinstance(img, Image.Image)
+    assert img.size == (8, 8)
+    # Custom headers are forwarded on the request.
+    get.assert_called_once()
+
+
+def test_capture_json_base64_vigilant_shape():
+    payload = base64.b64encode(_jpeg_bytes()).decode()
+    body = {"success": True, "data": payload}
+    cam = RestSnapshotCamera(
+        "cam",
+        "https://vigilant.cat/api/v1/cameras/uuid/snap",
+        headers={"Authorization": "Bearer secret"},
+        response="json",
+        json_path="data",
+        encoding="base64",
+    )
+    with patch.object(cam._session, "get", return_value=_response(json_body=body)):
+        img = cam.capture()
+    assert isinstance(img, Image.Image)
+    assert img.size == (8, 8)
+
+
+def test_capture_json_base64_strips_data_uri_prefix():
+    payload = "data:image/jpeg;base64," + base64.b64encode(_jpeg_bytes()).decode()
+    cam = RestSnapshotCamera("cam", "https://host/snap", response="json", json_path="result.image")
+    with patch.object(cam._session, "get", return_value=_response(json_body={"result": {"image": payload}})):
+        img = cam.capture()
+    assert isinstance(img, Image.Image)
+
+
+def test_capture_json_url_refetch():
+    cam = RestSnapshotCamera("cam", "https://host/meta", response="json", json_path="url", encoding="url")
+    meta = _response(json_body={"url": "https://cdn/host/frame.jpg"})
+    image = _response(content=_jpeg_bytes())
+    with patch.object(cam._session, "get", side_effect=[meta, image]) as get:
+        img = cam.capture()
+    assert isinstance(img, Image.Image)
+    assert get.call_count == 2
+
+
+def test_capture_returns_none_on_http_error():
+    cam = RestSnapshotCamera("cam", "https://host/snap", retries=0)
+    with patch.object(cam._session, "get", return_value=_response(status=500, content=b"<html>error</html>")):
+        assert cam.capture() is None
+
+
+def test_capture_retries_then_succeeds():
+    cam = RestSnapshotCamera("cam", "https://host/snap", retries=2)
+    ok = _response(content=_jpeg_bytes())
+    with patch.object(cam._session, "get", side_effect=[Exception("boom"), ok]) as get:
+        img = cam.capture()
+    assert isinstance(img, Image.Image)
+    assert get.call_count == 2
+
+
+def test_capture_gives_up_after_all_attempts():
+    cam = RestSnapshotCamera("cam", "https://host/snap", retries=2)
+    with patch.object(cam._session, "get", side_effect=Exception("boom")) as get:
+        assert cam.capture() is None
+    assert get.call_count == 3  # retries + 1
+
+
+def test_redaction_masks_secrets():
+    cam = RestSnapshotCamera("cam", "https://host/snap?token=abc123", headers={"Authorization": "Bearer secret"})
+    assert cam._redact_headers(cam.headers)["Authorization"] == "***"
+    assert "abc123" not in cam._redact_url(cam.url)


### PR DESCRIPTION
Adds a config-driven HTTP snapshot adapter for camera endpoints that need custom auth headers or return the image wrapped in JSON (base64 or a nested URL) — which the existing `URLCamera` cannot decode. Motivated by the vigilant.cat API (`Bearer` token + `{"data": "<base64 jpeg>"}`), but generic enough to reuse for any similar REST/aggregator API without new code.

## What changes
- New `RestSnapshotCamera` (`camera/adapters/rest.py`): `response` = `image` or `json`; dot-path extraction; `base64`/nested-`url` decoding; retries; sensitive headers and query params redacted in logs.
- Wired into `registry.py` as adapter `"rest"` (alias `"api"`); `${VAR}` placeholders in url/header values resolve from the environment, keeping tokens in `.env` rather than the mounted `credentials.json`.
- Security: for nested-`url` mode, auth headers are only forwarded when the nested URL is same-origin, to avoid leaking tokens to a CDN/other host.
- Deploy: `docker-compose.yml` now loads `.env` into the camera API service so `${VAR}` tokens reach the container.

## Config example (vigilant.cat)
```json
"vigilant_can_mitjans": {
  "adapter": "rest", "type": "static",
  "url": "https://vigilant.cat/api/v1/cameras/<uuid>/snap",
  "headers": {"Authorization": "Bearer ${VIGILANT_TOKEN}"},
  "response": "json", "json_path": "data", "encoding": "base64"
}
```

## Validation
- `pytest tests/test_rest_snapshot.py` — 10 passed
- `ruff check` + `ruff format --check` (changed files) — clean
- `mypy` (full project) — no issues in 45 files
- `docker compose config` — valid

## Notes
- The new tests live under `pyro_camera_api/tests/` and are not yet run by CI (`tests.yml` only runs the top-level `tests/`). Wiring `pyro_camera_api` into CI is a suggested follow-up.
- No token, camera UUID, or `credentials.json` is committed.