### PR TITLE
fix(watchdog): clock-free reboot budget reset and 2 min power cut

### DIFF
--- a/watchdog/shelly/TESTING.md
+++ b/watchdog/shelly/TESTING.md
@@ -60,7 +60,7 @@ python3 watchdog/shelly/check_station.py --cycle-pi        # Pi or PC
 ## Manual test (first station at least)
 
 Trigger the Shelly watchdog for real: stop the `/health` service and wait
-3 check intervals (~30 min) — the Shelly must cut outputs 0 and 1 for 20 s.
+3 check intervals (~30 min) — the Shelly must cut outputs 0 and 1 for 3 min.
 To speed it up, temporarily re-upload `watchdog.js` with a short
 `CHECK_INTERVAL_MS`, then restore it with `update_shelly_watchdog.sh`.
 

--- a/watchdog/shelly/TESTING.md
+++ b/watchdog/shelly/TESTING.md
@@ -60,7 +60,7 @@ python3 watchdog/shelly/check_station.py --cycle-pi        # Pi or PC
 ## Manual test (first station at least)
 
 Trigger the Shelly watchdog for real: stop the `/health` service and wait
-3 check intervals (~30 min) — the Shelly must cut outputs 0 and 1 for 3 min.
+3 check intervals (~30 min) — the Shelly must cut outputs 0 and 1 for 2 min.
 To speed it up, temporarily re-upload `watchdog.js` with a short
 `CHECK_INTERVAL_MS`, then restore it with `update_shelly_watchdog.sh`.
 

--- a/watchdog/shelly/device/README.md
+++ b/watchdog/shelly/device/README.md
@@ -27,7 +27,7 @@ Current configuration:
 | Pi health URL | `http://192.168.1.99:8081/health` |
 | Check interval | 10 minutes |
 | Consecutive failures before reboot | 3 |
-| Reboot duration | 3 minutes |
+| Reboot duration | 2 minutes |
 | Outputs rebooted | 0 and 1 |
 | Max reboots per outage | 3 |
 

--- a/watchdog/shelly/device/README.md
+++ b/watchdog/shelly/device/README.md
@@ -27,13 +27,21 @@ Current configuration:
 | Pi health URL | `http://192.168.1.99:8081/health` |
 | Check interval | 10 minutes |
 | Consecutive failures before reboot | 3 |
-| Reboot duration | 20 seconds |
+| Reboot duration | 3 minutes |
 | Outputs rebooted | 0 and 1 |
-| Max reboots per day | 3 |
+| Max reboots per outage | 3 |
+
+The reboot duration is long on purpose: a crashed Pi draws almost no current,
+so the power supply capacitors can keep it alive through a short cut.
+
+The reboot budget (3 attempts) resets when the Pi answers a health check again,
+or after 24 hours measured by a repeating timer. Timers only depend on uptime,
+so the reset works even when the Shelly has no NTP/internet and its wall-clock
+date is frozen.
 
 Important limitation:
 
-The daily reboot counter is stored in script memory. If the Shelly itself reboots, the counter is reset.
+The reboot counter is stored in script memory. If the Shelly itself reboots, the counter is reset.
 
 Make sure the Shelly is not powered by one of the outputs it cuts.
 

--- a/watchdog/shelly/device/README.md
+++ b/watchdog/shelly/device/README.md
@@ -35,7 +35,7 @@ The reboot duration is long on purpose: a crashed Pi draws almost no current,
 so the power supply capacitors can keep it alive through a short cut.
 
 The reboot budget (3 attempts) resets when the Pi answers a health check again,
-or after 24 hours measured by a repeating timer. Timers only depend on uptime,
+or after 12 hours measured by a repeating timer. Timers only depend on uptime,
 so the reset works even when the Shelly has no NTP/internet and its wall-clock
 date is frozen.
 

--- a/watchdog/shelly/device/watchdog.js
+++ b/watchdog/shelly/device/watchdog.js
@@ -12,8 +12,8 @@ let MAX_FAILURES = 3;
 let MAX_REBOOTS_PER_WINDOW = 3;
 // The Shelly has no NTP when the station is offline, so wall-clock dates are
 // unreliable. Timers only depend on uptime, so the budget is reset by a
-// repeating 24h timer instead of a date change.
-let RESET_WINDOW_MS = 24 * 60 * 60 * 1000;
+// repeating 12h timer instead of a date change.
+let RESET_WINDOW_MS = 12 * 60 * 60 * 1000;
 
 let failures = 0;
 let rebooting = false;
@@ -93,7 +93,7 @@ function checkPi() {
 }
 
 Timer.set(RESET_WINDOW_MS, true, function () {
-  resetRebootBudget("24h window elapsed");
+  resetRebootBudget("12h window elapsed");
 });
 Timer.set(CHECK_INTERVAL_MS, true, checkPi);
 checkPi();

--- a/watchdog/shelly/device/watchdog.js
+++ b/watchdog/shelly/device/watchdog.js
@@ -3,42 +3,31 @@ let PI_URL = "http://192.168.1.99:8081/health";
 let OUTPUT_IDS = [0, 1];
 
 let CHECK_INTERVAL_MS = 10 * 60 * 1000;
-let REBOOT_DURATION_MS = 20 * 1000;
+// A crashed Pi draws almost no current, so the PSU capacitors keep it powered
+// through a short cut. 3 minutes guarantees a real power loss.
+let REBOOT_DURATION_MS = 3 * 60 * 1000;
 
 let MAX_FAILURES = 3;
-let MAX_REBOOTS_PER_DAY = 3;
+let MAX_REBOOTS_PER_WINDOW = 3;
+// The Shelly has no NTP when the station is offline, so wall-clock dates are
+// unreliable. Timers only depend on uptime, so the budget is reset by a
+// repeating 24h timer instead of a date change.
+let RESET_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 let failures = 0;
 let rebooting = false;
+let rebootCount = 0;
 
-let currentDay = "";
-let rebootsToday = 0;
-
-function getDayKey() {
-  let now = new Date();
-  return now.getFullYear() + "/" + (now.getMonth() + 1) + "/" + now.getDate();
-}
-
-function resetDailyCounterIfNeeded() {
-  let dayKey = getDayKey();
-
-  if (currentDay === "") {
-    currentDay = dayKey;
-    return;
+function resetRebootBudget(reason) {
+  if (rebootCount > 0) {
+    print("Reboot budget reset (" + reason + ")");
   }
-
-  if (dayKey !== currentDay) {
-    currentDay = dayKey;
-    rebootsToday = 0;
-    print("New day, reboot counter reset");
-  }
+  rebootCount = 0;
 }
 
 function canReboot() {
-  resetDailyCounterIfNeeded();
-
-  if (rebootsToday >= MAX_REBOOTS_PER_DAY) {
-    print("Daily reboot limit reached, skip reboot");
+  if (rebootCount >= MAX_REBOOTS_PER_WINDOW) {
+    print("Reboot limit reached, skip reboot");
     return false;
   }
 
@@ -62,10 +51,10 @@ function rebootOutputs() {
   }
 
   rebooting = true;
-  rebootsToday = rebootsToday + 1;
+  rebootCount = rebootCount + 1;
 
   print("Pi unreachable, rebooting outputs 0 and 1");
-  print("Reboots today: " + rebootsToday);
+  print("Reboots this window: " + rebootCount);
 
   turnOutputs(false);
 
@@ -77,8 +66,6 @@ function rebootOutputs() {
 }
 
 function checkPi() {
-  resetDailyCounterIfNeeded();
-
   if (rebooting) {
     print("Reboot running, skip check");
     return;
@@ -90,6 +77,7 @@ function checkPi() {
     function (result, error_code, error_message) {
       if (error_code === 0 && result && result.code === 200) {
         failures = 0;
+        resetRebootBudget("Pi healthy");
       } else {
         failures = failures + 1;
         print("Pi failed, count " + failures + " (" + (error_message || "bad status") + ")");
@@ -103,6 +91,8 @@ function checkPi() {
   );
 }
 
-resetDailyCounterIfNeeded();
+Timer.set(RESET_WINDOW_MS, true, function () {
+  resetRebootBudget("24h window elapsed");
+});
 Timer.set(CHECK_INTERVAL_MS, true, checkPi);
 checkPi();

--- a/watchdog/shelly/device/watchdog.js
+++ b/watchdog/shelly/device/watchdog.js
@@ -4,8 +4,9 @@ let OUTPUT_IDS = [0, 1];
 
 let CHECK_INTERVAL_MS = 10 * 60 * 1000;
 // A crashed Pi draws almost no current, so the PSU capacitors keep it powered
-// through a short cut. 3 minutes guarantees a real power loss.
-let REBOOT_DURATION_MS = 3 * 60 * 1000;
+// through a short cut. 2 minutes guarantees a real power loss (~1 min was
+// enough in the field).
+let REBOOT_DURATION_MS = 2 * 60 * 1000;
 
 let MAX_FAILURES = 3;
 let MAX_REBOOTS_PER_WINDOW = 3;


### PR DESCRIPTION
Field debugging on a station showed two failure modes in the Shelly watchdog:

- The reboot budget used a wall-clock daily reset, but an offline Shelly has no NTP so the date freezes and the budget never resets once exhausted. The budget now resets on a successful health check and via a repeating 12h timer (uptime-based, works without a clock).
- The 20 s power cut is too short: a crashed Pi draws almost no current, so the PSU capacitors keep it powered through the cut. The cut is now 2 minutes (validated on site).

Docs updated accordingly (device README and TESTING.md).