### PR TITLE
feat(engine): send capture time as recorded_at on detection upload

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -658,7 +658,7 @@ class Engine(Predictor):
         self,
         context_crop: Optional[ContextCrop],
         cam_id: str,
-        ts: int,
+        ts: str,
         bboxes: list,
         jpeg_bytes: Optional[bytes] = None,
         crop_boxes: Optional[list] = None,
@@ -718,7 +718,9 @@ class Engine(Predictor):
                     )
                     _, pose_id = self.cam_creds[cam_id]
                     ip = cam_id.split("_")[0]
-                    response = self.api_client[ip].create_detection(jpeg_bytes, bboxes, pose_id, crops=crops)
+                    response = self.api_client[ip].create_detection(
+                        jpeg_bytes, bboxes, pose_id, crops=crops, recorded_at=frame_info["ts"]
+                    )
 
                     try:
                         response.json()["id"]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -548,7 +548,8 @@ def test_process_alerts_sends_one_crop_per_bbox(tmp_path):
     crop_boxes = [engine._compute_crop_box([b], 640, 480) for b in bboxes]
     buf = io.BytesIO()
     frame.save(buf, format="JPEG")
-    engine._stage_alert(context, cam_id, int(time.time()), bboxes, jpeg_bytes=buf.getvalue(), crop_boxes=crop_boxes)
+    ts = "2026-07-21T12:00:00.000000+00:00"
+    engine._stage_alert(context, cam_id, ts, bboxes, jpeg_bytes=buf.getvalue(), crop_boxes=crop_boxes)
 
     engine._process_alerts()
 
@@ -556,6 +557,7 @@ def test_process_alerts_sends_one_crop_per_bbox(tmp_path):
     crops = fake_client.create_detection.call_args.kwargs["crops"]
     assert len(crops) == 2
     assert all(isinstance(c, bytes) for c in crops)
+    assert fake_client.create_detection.call_args.kwargs["recorded_at"] == ts
     assert len(engine._alerts) == 0
 
 
@@ -564,7 +566,7 @@ def test_process_alerts_placeholder_bbox_sends_no_crop(tmp_path):
     buf = io.BytesIO()
     Image.new("RGB", (640, 480)).save(buf, format="JPEG")
     # Empty bboxes -> fill_empty_bboxes stamps the placeholder; no context crop / crop boxes.
-    engine._stage_alert(None, cam_id, int(time.time()), bboxes=[], jpeg_bytes=buf.getvalue())
+    engine._stage_alert(None, cam_id, "2026-07-21T12:00:00.000000+00:00", bboxes=[], jpeg_bytes=buf.getvalue())
 
     engine._process_alerts()
 


### PR DESCRIPTION
## Motivation

Detections cached on the engine and uploaded in a burst all land at the same `created_at` on the API, which breaks time based sequence linking. pyronear/pyro-api#617 adds a `recorded_at` field carrying the on-device capture time.

## What changed

- `_process_alerts` now forwards the queued frame timestamp (UTC ISO, stamped at inference time) as `recorded_at` to `create_detection`.
- Fixed the `ts` annotation on `_stage_alert` (`int` to `str`, it always carried an ISO string) and asserted the forwarding in tests.

## Blocked on

pyro-api#617: `pyroclient.create_detection` must gain the optional `recorded_at` parameter, then the pin in `requirements-git.txt` and `uv.lock` needs a bump to that commit before merging. Until then the integration tests fail with `TypeError: unexpected keyword argument 'recorded_at'`.