### PR TITLE
feat(camera): azimuth tracking and move-to-azimuth for PTZ cameras

### DIFF
--- a/pyro_camera_api/client/pyro_camera_api_client/client.py
+++ b/pyro_camera_api/client/pyro_camera_api_client/client.py
@@ -292,7 +292,8 @@ class PyroCameraAPIClient:
         """Return the camera's current real-world azimuth.
 
         Response: {"camera_ip", "azimuth_deg" (null when unknown),
-        "source" ("hardware" or "tracked"), "moving"}.
+        "source" ("hardware" or "tracked"), "moving", "zoom",
+        "h_fov_deg" (calibrated horizontal FOV at the current zoom)}.
         """
         params = {"camera_ip": camera_ip}
         resp = self._request("GET", "/control/azimuth", params=params)

--- a/pyro_camera_api/client/pyro_camera_api_client/client.py
+++ b/pyro_camera_api/client/pyro_camera_api_client/client.py
@@ -199,7 +199,11 @@ class PyroCameraAPIClient:
         if duration is not None:
             params["duration"] = duration
 
-        resp = self._request("POST", "/control/move", params=params)
+        # Preset moves block server-side while the camera travels (lock hold),
+        # and duration/degrees modes sleep for the move time: use a timeout
+        # that covers the longest server-side wait.
+        req_timeout = self.timeout if (pose_id is None and duration is None and degrees is None) else 30.0
+        resp = self._request("POST", "/control/move", params=params, timeout=req_timeout)
         return resp.json()
 
     # ------------------------------------------------------------------
@@ -207,9 +211,13 @@ class PyroCameraAPIClient:
     # ------------------------------------------------------------------
 
     def goto_preset(self, camera_ip: str, pose_id: int, speed: int = 50) -> Dict[str, Any]:
-        """Move to a configured preset pose. Returns immediately."""
+        """Move to a configured preset pose.
+
+        Blocks until the camera has settled: the server holds the per-camera
+        lock while fire-and-forget adapters (Reolink) travel to the pose.
+        """
         params = {"camera_ip": camera_ip, "pose_id": pose_id, "speed": speed}
-        resp = self._request("POST", "/control/goto_preset", params=params)
+        resp = self._request("POST", "/control/goto_preset", params=params, timeout=30.0)
         return resp.json()
 
     def start_move(self, camera_ip: str, direction: str, speed: int = 10) -> Dict[str, Any]:

--- a/pyro_camera_api/client/pyro_camera_api_client/client.py
+++ b/pyro_camera_api/client/pyro_camera_api_client/client.py
@@ -310,7 +310,8 @@ class PyroCameraAPIClient:
         return resp.json()
 
     def zoom(self, camera_ip: str, level: int) -> Dict[str, Any]:
-        resp = self._request("POST", f"/control/zoom/{camera_ip}/{level}")
+        # The server holds the per-camera lock while the zoom settles (~2-10 s).
+        resp = self._request("POST", f"/control/zoom/{camera_ip}/{level}", timeout=30.0)
         return resp.json()
 
     def reboot_camera(self, camera_ip: str) -> Dict[str, Any]:

--- a/pyro_camera_api/client/pyro_camera_api_client/client.py
+++ b/pyro_camera_api/client/pyro_camera_api_client/client.py
@@ -294,6 +294,12 @@ class PyroCameraAPIClient:
         Response: {"camera_ip", "azimuth_deg" (null when unknown),
         "source" ("hardware" or "tracked"), "moving", "zoom",
         "h_fov_deg" (calibrated horizontal FOV at the current zoom)}.
+
+        When "moving" is true and "source" is "tracked", "azimuth_deg" is the
+        destination of the in-flight preset move rather than the current
+        position ("hardware" reads back the actual mid-travel position).
+        "moving" only reflects the server-side PTZ lock, so a camera moving
+        under patrol reports false.
         """
         params = {"camera_ip": camera_ip}
         resp = self._request("GET", "/control/azimuth", params=params)

--- a/pyro_camera_api/client/pyro_camera_api_client/client.py
+++ b/pyro_camera_api/client/pyro_camera_api_client/client.py
@@ -300,11 +300,13 @@ class PyroCameraAPIClient:
 
     def move_to_azimuth(self, camera_ip: str, azimuth: float, speed: Optional[int] = None) -> Dict[str, Any]:
         """Move to an absolute real-world azimuth. Blocks while the camera
-        moves; raises on 409 if busy or if the tracked azimuth is unknown."""
+        recalls the closest preset then pans the residual (preset hold plus a
+        residual that can crawl at ~1.5 °/s when zoom > 0, hence the margin);
+        raises on 409 if busy or if pose azimuths are not resolved yet."""
         params: Dict[str, Any] = {"camera_ip": camera_ip, "azimuth": azimuth}
         if speed is not None:
             params["speed"] = speed
-        resp = self._request("POST", "/control/move_to_azimuth", params=params, timeout=30.0)
+        resp = self._request("POST", "/control/move_to_azimuth", params=params, timeout=60.0)
         return resp.json()
 
     def get_speed_tables(self, camera_ip: str) -> Dict[str, Any]:

--- a/pyro_camera_api/client/pyro_camera_api_client/client.py
+++ b/pyro_camera_api/client/pyro_camera_api_client/client.py
@@ -298,17 +298,6 @@ class PyroCameraAPIClient:
         resp = self._request("GET", "/control/azimuth", params=params)
         return resp.json()
 
-    def move_to_azimuth(self, camera_ip: str, azimuth: float, speed: Optional[int] = None) -> Dict[str, Any]:
-        """Move to an absolute real-world azimuth. Blocks while the camera
-        recalls the closest preset then pans the residual (preset hold plus a
-        residual that can crawl at ~1.5 °/s when zoom > 0, hence the margin);
-        raises on 409 if busy or if pose azimuths are not resolved yet."""
-        params: Dict[str, Any] = {"camera_ip": camera_ip, "azimuth": azimuth}
-        if speed is not None:
-            params["speed"] = speed
-        resp = self._request("POST", "/control/move_to_azimuth", params=params, timeout=60.0)
-        return resp.json()
-
     def get_speed_tables(self, camera_ip: str) -> Dict[str, Any]:
         params = {"camera_ip": camera_ip}
         resp = self._request("GET", "/control/speed_tables", params=params)

--- a/pyro_camera_api/client/pyro_camera_api_client/client.py
+++ b/pyro_camera_api/client/pyro_camera_api_client/client.py
@@ -288,6 +288,25 @@ class PyroCameraAPIClient:
         resp = self._request("POST", "/control/click_to_move", params=params, timeout=30.0)
         return resp.json()
 
+    def get_azimuth(self, camera_ip: str) -> Dict[str, Any]:
+        """Return the camera's current real-world azimuth.
+
+        Response: {"camera_ip", "azimuth_deg" (null when unknown),
+        "source" ("hardware" or "tracked"), "moving"}.
+        """
+        params = {"camera_ip": camera_ip}
+        resp = self._request("GET", "/control/azimuth", params=params)
+        return resp.json()
+
+    def move_to_azimuth(self, camera_ip: str, azimuth: float, speed: Optional[int] = None) -> Dict[str, Any]:
+        """Move to an absolute real-world azimuth. Blocks while the camera
+        moves; raises on 409 if busy or if the tracked azimuth is unknown."""
+        params: Dict[str, Any] = {"camera_ip": camera_ip, "azimuth": azimuth}
+        if speed is not None:
+            params["speed"] = speed
+        resp = self._request("POST", "/control/move_to_azimuth", params=params, timeout=30.0)
+        return resp.json()
+
     def get_speed_tables(self, camera_ip: str) -> Dict[str, Any]:
         params = {"camera_ip": camera_ip}
         resp = self._request("GET", "/control/speed_tables", params=params)

--- a/pyro_camera_api/pyro_camera_api/api/routes_control.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_control.py
@@ -555,11 +555,6 @@ def _interruptible_sleep(camera_ip: str, duration: float) -> bool:
     return STOP_EVENTS[camera_ip].wait(timeout=duration)
 
 
-def _shortest_delta_deg(current: float, target: float) -> float:
-    """Signed shortest rotation from current to target azimuth, in [-180, 180)."""
-    return ((target - current + 180.0) % 360.0) - 180.0
-
-
 def _update_tracked_azimuth(cam: PTZMixin, start_azimuth: Optional[float], direction: str, degrees: float) -> None:
     """Dead-reckon the azimuth after a completed timed pan move.
 
@@ -892,122 +887,6 @@ def get_camera_azimuth(camera_ip: str):
         "zoom": zoom,
         "h_fov_deg": round(h_fov, 2),
     }
-
-
-@router.post("/move_to_azimuth")
-def move_to_azimuth(camera_ip: str, azimuth: float, speed: Optional[int] = None):
-    """Move the camera to an absolute real-world azimuth in degrees.
-
-    Hardware adapters (Linovision) execute a blocking absolute move. Tracked
-    adapters (Reolink) first recall the preset pose whose azimuth is closest
-    to the target (fast hardware travel that also re-anchors the dead-reckoned
-    reference), then correct the small residual with a calibrated timed pan
-    (same semantics as /move_by_degrees: auto speed pick, zoom cap,
-    micro-impulse). The residual is bounded by half the inter-pose spacing,
-    so the blocking time stays click_to_move-sized even at zoom > 0.
-
-    Returns 409 when the camera is busy, or when the pose azimuths have not
-    been resolved from the platform API yet (no anchor available).
-    """
-    update_command_time()
-    cam = _require_ptz(camera_ip)
-    target = azimuth % 360.0
-
-    if hasattr(cam, "move_to_azimuth"):
-        # Hardware absolute move, blocking until the camera reports arrival.
-        lock = _acquire_or_409(camera_ip)
-        try:
-            logger.info("[%s] move_to_azimuth %.2f° (hardware)", camera_ip, target)
-            ptz_status = cam.move_to_azimuth(target)
-            return {
-                "status": "ok",
-                "camera_ip": camera_ip,
-                "azimuth_deg": round(target, 2),
-                "source": "hardware",
-                "ptz_status": ptz_status,
-            }
-        except Exception as exc:
-            logger.error("[%s] move_to_azimuth error: %s", camera_ip, exc)
-            raise HTTPException(status_code=500, detail=str(exc))
-        finally:
-            lock.release()
-
-    conf = RAW_CONFIG.get(camera_ip, {})
-    adapter = _resolve_adapter(conf.get("adapter", "unknown"))
-
-    poses = list(getattr(cam, "cam_poses", []) or [])
-    azimuths = list(getattr(cam, "cam_azimuths", []) or [])
-    if not azimuths or len(azimuths) != len(poses):
-        raise HTTPException(
-            status_code=409,
-            detail="Pose azimuths not resolved from the platform API yet; cannot anchor an absolute move",
-        )
-
-    # Hold one lock across the whole anchor-then-correct sequence so a
-    # concurrent command cannot slip in between the preset recall and the
-    # residual pan.
-    lock = _acquire_or_409(camera_ip)
-    try:
-        # Same skip threshold as click_to_move: below half the speed-1 coast
-        # bias, a micro-impulse would overshoot more than staying put.
-        skip_threshold = PAN_BIAS.get(adapter, {}).get(1, 1.0) / 2
-        current = cam.get_azimuth()
-        if current is not None and abs(_shortest_delta_deg(current, target)) < skip_threshold:
-            return {
-                "status": "ok",
-                "camera_ip": camera_ip,
-                "azimuth_deg": round(current, 2),
-                "source": "tracked",
-                "skipped": True,
-                "delta_deg": round(_shortest_delta_deg(current, target), 3),
-            }
-
-        # Anchor on the preset pose closest to the target: preset recall runs
-        # at hardware speed regardless of zoom, and re-sets the dead-reckoned
-        # reference, so drift cannot accumulate across absolute moves.
-        pose_id, pose_azimuth = min(
-            zip(poses, azimuths, strict=True),
-            key=lambda pair: abs(_shortest_delta_deg(pair[1], target)),
-        )
-        logger.info(
-            "[%s] move_to_azimuth %.2f° via pose %s (%.2f°)",
-            camera_ip,
-            target,
-            pose_id,
-            pose_azimuth,
-        )
-        cam.move_camera("ToPos", speed=50, idx=pose_id)
-        resp: dict = {
-            "status": "ok",
-            "camera_ip": camera_ip,
-            "source": "tracked",
-            "target_azimuth_deg": round(target, 2),
-            "pose_id": pose_id,
-            "pose_azimuth_deg": round(pose_azimuth, 2),
-        }
-        _hold_for_preset_move(cam, camera_ip, resp)
-        if resp.get("interrupted"):
-            resp["azimuth_deg"] = None
-            return resp
-
-        residual = _shortest_delta_deg(pose_azimuth, target)
-        if abs(residual) >= skip_threshold:
-            direction = "Right" if residual > 0 else "Left"
-            move_resp = _execute_degrees_move(cam, camera_ip, direction, abs(residual), speed, adapter)
-            resp["residual_move"] = move_resp
-            if move_resp.get("interrupted"):
-                resp["interrupted"] = True
-
-        tracked = cam.get_azimuth()
-        resp["azimuth_deg"] = None if tracked is None else round(tracked, 2)
-        return resp
-    except HTTPException:
-        raise
-    except Exception as exc:
-        logger.error("[%s] move_to_azimuth error: %s", camera_ip, exc)
-        raise HTTPException(status_code=500, detail=str(exc))
-    finally:
-        lock.release()
 
 
 @router.get("/speed_tables")

--- a/pyro_camera_api/pyro_camera_api/api/routes_control.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_control.py
@@ -857,6 +857,15 @@ def get_camera_azimuth(camera_ip: str):
     interrupted or untimed free move. ``moving`` reflects whether a blocking
     PTZ command currently holds the per-camera lock.
 
+    Read ``azimuth_deg`` together with ``moving``: for tracked adapters, a
+    non-null value under ``moving: true`` is the destination of an in-flight
+    preset move, not the current position (hardware adapters read back the
+    actual mid-travel position). ``moving`` only tracks the per-camera lock,
+    which the patrol loop does not take, so a patrolling camera reports
+    ``moving: false`` while physically turning; callers that need a
+    trustworthy position must stop the patrol first, as they already do for
+    manual control.
+
     ``zoom`` and ``h_fov_deg`` describe the current field of view: the zoom
     level is read from the camera and the horizontal FOV comes from the
     calibrated tables (fov_at_zoom). For adapters without calibration

--- a/pyro_camera_api/pyro_camera_api/api/routes_control.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_control.py
@@ -229,6 +229,8 @@ def click_to_move(
         if zoom > 0:
             result["warning"] = f"speed limited to 1 (zoom={zoom} > 0)"
 
+        start_azimuth = _start_azimuth_for_tracking(cam)
+
         def _execute_axis(axis: str, deg: float, direction: str, speeds: dict, bias: dict) -> bool:
             """Execute a single-axis move: calibrated duration, or micro-pulse if below bias.
             Returns True if the move was interrupted by /stop."""
@@ -248,6 +250,8 @@ def click_to_move(
                 cam.move_camera(direction, speed=speed_level)
                 interrupted = _interruptible_sleep(camera_ip, dur)
                 cam.move_camera("Stop")
+                if not interrupted:
+                    _update_tracked_azimuth(cam, start_azimuth, direction, abs(deg))
                 entry: dict = {
                     "axis": axis,
                     "direction": direction,
@@ -266,6 +270,8 @@ def click_to_move(
                 )
                 cam.move_camera(direction, speed=1)
                 cam.move_camera("Stop")
+                # A micro-impulse physically moves about the speed-1 coast bias.
+                _update_tracked_azimuth(cam, start_azimuth, direction, bias.get(1, 0.0))
                 result["moves"].append({
                     "axis": axis,
                     "direction": direction,
@@ -345,7 +351,8 @@ def move_camera(
         if pose_id is not None:
             logger.info("[%s] Moving to preset pose %s at speed %s", camera_ip, pose_id, speed)
             cam.move_camera("ToPos", speed=speed, idx=pose_id)
-            return {"status": "ok", "camera_ip": camera_ip, "pose_id": pose_id, "speed": speed}
+            pose_resp: dict = {"status": "ok", "camera_ip": camera_ip, "pose_id": pose_id, "speed": speed}
+            return _hold_for_preset_move(cam, camera_ip, pose_resp)
 
         if duration is not None and direction:
             logger.info(
@@ -416,6 +423,7 @@ def move_camera(
             # Micro-impulse: angle below bias → move+stop at speed 1
             micro = duration_sec == 0.0 and abs(degrees) > 0
             interrupted = False
+            start_azimuth = _start_azimuth_for_tracking(cam)
             if micro:
                 logger.info(
                     "[%s] Moving %s %.2f° micro-impulse speed=1 (adapter=%s)",
@@ -438,6 +446,11 @@ def move_camera(
                 cam.move_camera(direction, speed=effective_speed)
                 interrupted = _interruptible_sleep(camera_ip, duration_sec)
                 cam.move_camera("Stop")
+
+            if not interrupted:
+                # A micro-impulse physically moves about the speed-1 coast bias.
+                moved_deg = get_pan_bias(adapter, 1) if micro else abs(degrees)
+                _update_tracked_azimuth(cam, start_azimuth, direction, moved_deg)
 
             resp = {
                 "status": "ok",
@@ -541,18 +554,71 @@ def _interruptible_sleep(camera_ip: str, duration: float) -> bool:
     return STOP_EVENTS[camera_ip].wait(timeout=duration)
 
 
+# Reolink executes ToPos asynchronously with no completion feedback, so preset
+# moves hold the per-camera lock for this conservative duration to enforce
+# "no concurrent command while the camera is moving". Linovision preset moves
+# already block inside the adapter until the target azimuth is reached.
+PRESET_MOVE_HOLD_S = 5.0
+
+
+def _shortest_delta_deg(current: float, target: float) -> float:
+    """Signed shortest rotation from current to target azimuth, in [-180, 180)."""
+    return ((target - current + 180.0) % 360.0) - 180.0
+
+
+def _update_tracked_azimuth(cam: PTZMixin, start_azimuth: Optional[float], direction: str, degrees: float) -> None:
+    """Dead-reckon the azimuth after a completed timed pan move.
+
+    ``start_azimuth`` must be captured before the move starts (the adapter
+    invalidates its tracked azimuth when a pan operation begins). No-op for
+    hardware-reported adapters, tilt moves, or when the azimuth was unknown.
+    """
+    if cam.azimuth_source != "tracked" or not hasattr(cam, "current_azimuth"):
+        return
+    if start_azimuth is None or direction not in ("Left", "Right"):
+        return
+    signed = degrees if direction == "Right" else -degrees
+    cam.current_azimuth = (start_azimuth + signed) % 360.0
+
+
+def _start_azimuth_for_tracking(cam: PTZMixin) -> Optional[float]:
+    """Snapshot the tracked azimuth before a move; None for hardware adapters."""
+    return cam.get_azimuth() if cam.azimuth_source == "tracked" else None
+
+
+def _hold_for_preset_move(cam: PTZMixin, camera_ip: str, resp: dict) -> dict:
+    """Hold the per-camera lock while a fire-and-forget preset move completes.
+
+    Only applies to tracked-source adapters (Reolink-style async ToPos). If the
+    hold is interrupted by /stop, the camera stopped between poses, so the
+    tracked azimuth set at command time is invalidated.
+    """
+    if cam.azimuth_source != "tracked":
+        return resp
+    resp["hold_s"] = PRESET_MOVE_HOLD_S
+    if _interruptible_sleep(camera_ip, PRESET_MOVE_HOLD_S):
+        resp["interrupted"] = True
+        if hasattr(cam, "current_azimuth"):
+            cam.current_azimuth = None
+    return resp
+
+
 @router.post("/goto_preset")
 def goto_preset(camera_ip: str, pose_id: int, speed: int = 50):
-    """Move a PTZ camera to a configured preset pose. Returns immediately;
-    the camera completes the move asynchronously. Acquires the per-camera
-    lock to gate against interrupting an in-flight blocking PTZ op → 409 if busy."""
+    """Move a PTZ camera to a configured preset pose.
+
+    For adapters with fire-and-forget preset moves (Reolink) the per-camera
+    lock is held for a conservative duration while the camera travels, so
+    concurrent PTZ commands get a 409. Linovision blocks until the pose is
+    reached. Returns 409 if the camera is already busy."""
     update_command_time()
     cam = _require_ptz(camera_ip)
     lock = _acquire_or_409(camera_ip)
     try:
         logger.info("[%s] goto_preset %s speed=%s", camera_ip, pose_id, speed)
         cam.move_camera("ToPos", speed=speed, idx=pose_id)
-        return {"status": "ok", "camera_ip": camera_ip, "pose_id": pose_id, "speed": speed}
+        resp: dict = {"status": "ok", "camera_ip": camera_ip, "pose_id": pose_id, "speed": speed}
+        return _hold_for_preset_move(cam, camera_ip, resp)
     except Exception as exc:
         logger.error("[%s] goto_preset error: %s", camera_ip, exc)
         raise HTTPException(status_code=500, detail=str(exc))
@@ -724,6 +790,7 @@ def move_by_degrees(
         duration_sec = max(0.0, (abs(degrees) - bias) / deg_per_sec)
         micro = duration_sec == 0.0 and abs(degrees) > 0
         interrupted = False
+        start_azimuth = _start_azimuth_for_tracking(cam)
 
         if micro:
             logger.info(
@@ -749,6 +816,11 @@ def move_by_degrees(
             interrupted = _interruptible_sleep(camera_ip, duration_sec)
             cam.move_camera("Stop")
 
+        if not interrupted:
+            # A micro-impulse physically moves about the speed-1 coast bias.
+            moved_deg = get_pan_bias(adapter, 1) if micro else abs(degrees)
+            _update_tracked_azimuth(cam, start_azimuth, direction, moved_deg)
+
         resp: dict = {
             "status": "ok",
             "camera_ip": camera_ip,
@@ -770,6 +842,95 @@ def move_by_degrees(
         raise HTTPException(status_code=500, detail=str(exc))
     finally:
         lock.release()
+
+
+@router.get("/azimuth")
+def get_camera_azimuth(camera_ip: str):
+    """Return the camera's current real-world azimuth in degrees.
+
+    ``source`` is "hardware" when the value is read back from the camera
+    (Linovision) and "tracked" when it is dead-reckoned from commanded moves
+    (Reolink). For tracked adapters ``azimuth_deg`` is null until a preset
+    move (patrol pass or /goto_preset) provides a reference, and after an
+    interrupted or untimed free move. ``moving`` reflects whether a blocking
+    PTZ command currently holds the per-camera lock.
+    """
+    cam = _require_ptz(camera_ip)
+    azimuth = cam.get_azimuth()
+    return {
+        "camera_ip": camera_ip,
+        "azimuth_deg": None if azimuth is None else round(azimuth, 2),
+        "source": cam.azimuth_source,
+        "moving": MOVE_LOCKS[camera_ip].locked(),
+    }
+
+
+@router.post("/move_to_azimuth")
+def move_to_azimuth(camera_ip: str, azimuth: float, speed: Optional[int] = None):
+    """Move the camera to an absolute real-world azimuth in degrees.
+
+    Hardware adapters (Linovision) execute a blocking absolute move. Tracked
+    adapters (Reolink) rotate by the shortest signed delta from the current
+    dead-reckoned azimuth using the calibrated speed tables, reusing the
+    /move_by_degrees semantics (auto speed pick, zoom cap, micro-impulse).
+
+    Returns 409 when the camera is busy, or when the tracked azimuth is still
+    unknown (no preset move since boot; wait for a patrol pass or call
+    /goto_preset first).
+    """
+    update_command_time()
+    cam = _require_ptz(camera_ip)
+    target = azimuth % 360.0
+
+    if hasattr(cam, "move_to_azimuth"):
+        # Hardware absolute move, blocking until the camera reports arrival.
+        lock = _acquire_or_409(camera_ip)
+        try:
+            logger.info("[%s] move_to_azimuth %.2f° (hardware)", camera_ip, target)
+            ptz_status = cam.move_to_azimuth(target)
+            return {
+                "status": "ok",
+                "camera_ip": camera_ip,
+                "azimuth_deg": round(target, 2),
+                "source": "hardware",
+                "ptz_status": ptz_status,
+            }
+        except Exception as exc:
+            logger.error("[%s] move_to_azimuth error: %s", camera_ip, exc)
+            raise HTTPException(status_code=500, detail=str(exc))
+        finally:
+            lock.release()
+
+    current = cam.get_azimuth()
+    if current is None:
+        raise HTTPException(
+            status_code=409,
+            detail="Camera azimuth unknown; wait for a patrol pass or call /goto_preset first",
+        )
+
+    delta = _shortest_delta_deg(current, target)
+    conf = RAW_CONFIG.get(camera_ip, {})
+    adapter = _resolve_adapter(conf.get("adapter", "unknown"))
+
+    # Same skip threshold as click_to_move: below half the speed-1 coast bias,
+    # a micro-impulse would overshoot more than staying put.
+    if abs(delta) < PAN_BIAS.get(adapter, {}).get(1, 1.0) / 2:
+        return {
+            "status": "ok",
+            "camera_ip": camera_ip,
+            "azimuth_deg": round(current, 2),
+            "source": "tracked",
+            "skipped": True,
+            "delta_deg": round(delta, 3),
+        }
+
+    direction = "Right" if delta > 0 else "Left"
+    resp = move_by_degrees(camera_ip=camera_ip, direction=direction, degrees=abs(delta), speed=speed)
+    resp["source"] = "tracked"
+    resp["target_azimuth_deg"] = round(target, 2)
+    tracked = cam.get_azimuth()
+    resp["azimuth_deg"] = None if tracked is None else round(tracked, 2)
+    return resp
 
 
 @router.get("/speed_tables")

--- a/pyro_camera_api/pyro_camera_api/api/routes_control.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_control.py
@@ -554,13 +554,6 @@ def _interruptible_sleep(camera_ip: str, duration: float) -> bool:
     return STOP_EVENTS[camera_ip].wait(timeout=duration)
 
 
-# Reolink executes ToPos asynchronously with no completion feedback, so preset
-# moves hold the per-camera lock for this conservative duration to enforce
-# "no concurrent command while the camera is moving". Linovision preset moves
-# already block inside the adapter until the target azimuth is reached.
-PRESET_MOVE_HOLD_S = 5.0
-
-
 def _shortest_delta_deg(current: float, target: float) -> float:
     """Signed shortest rotation from current to target azimuth, in [-180, 180)."""
     return ((target - current + 180.0) % 360.0) - 180.0
@@ -589,14 +582,15 @@ def _start_azimuth_for_tracking(cam: PTZMixin) -> Optional[float]:
 def _hold_for_preset_move(cam: PTZMixin, camera_ip: str, resp: dict) -> dict:
     """Hold the per-camera lock while a fire-and-forget preset move completes.
 
-    Only applies to tracked-source adapters (Reolink-style async ToPos). If the
-    hold is interrupted by /stop, the camera stopped between poses, so the
-    tracked azimuth set at command time is invalidated.
+    Only applies to adapters with a non-zero preset_move_hold_s (Reolink-style
+    async ToPos). If the hold is interrupted by /stop, the camera stopped
+    between poses, so the tracked azimuth set at command time is invalidated.
     """
-    if cam.azimuth_source != "tracked":
+    hold_s = cam.preset_move_hold_s
+    if hold_s <= 0:
         return resp
-    resp["hold_s"] = PRESET_MOVE_HOLD_S
-    if _interruptible_sleep(camera_ip, PRESET_MOVE_HOLD_S):
+    resp["hold_s"] = hold_s
+    if _interruptible_sleep(camera_ip, hold_s):
         resp["interrupted"] = True
         if hasattr(cam, "current_azimuth"):
             cam.current_azimuth = None
@@ -718,123 +712,7 @@ def move_by_degrees(
 
     lock = _acquire_or_409(camera_ip)
     try:
-        zoom = 0
-        if hasattr(cam, "get_focus_level"):
-            try:
-                info = cam.get_focus_level() or {}
-                z = info.get("zoom")
-                if z is not None:
-                    zoom = int(z)
-            except Exception as exc:
-                logger.warning("[%s] move_by_degrees: failed to read zoom, assuming 0: %s", camera_ip, exc)
-
-        axis_speeds = PAN_SPEEDS.get(adapter, {}) if direction in ("Left", "Right") else TILT_SPEEDS.get(adapter, {})
-        axis_bias = PAN_BIAS.get(adapter, {}) if direction in ("Left", "Right") else TILT_BIAS.get(adapter, {})
-
-        # Reject out-of-range explicit speeds up-front rather than silently
-        # downgrading them later. The server enforces the rule that matches
-        # physical reality: at zoom 0 only calibrated levels are valid, and
-        # at zoom > 0 only speed 1 is honored by Reolink hardware.
-        if speed is not None:
-            if zoom > 0 and speed != 1:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"speed={speed} invalid at zoom={zoom}: Reolink caps all speeds "
-                        f"to speed 1 (~1.5 °/s) above zoom 0. Pass speed=1 or omit 'speed' "
-                        f"to auto-pick."
-                    ),
-                )
-            if axis_speeds and speed not in axis_speeds:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"speed={speed} not in calibrated table for adapter '{adapter}' "
-                        f"(levels: {sorted(axis_speeds)}). Omit 'speed' to auto-pick."
-                    ),
-                )
-
-        # Auto-pick the calibrated speed level when caller didn't specify one.
-        # _pick_speed restricts to speed 1 at zoom > 0, and may return None
-        # for angles below bias[1] — those become a micro-impulse below.
-        auto_speed = speed is None
-        if auto_speed:
-            picked = _pick_speed(abs(degrees), axis_speeds, axis_bias, zoom=zoom) if axis_speeds else None
-            speed = picked if picked is not None else 1
-
-        # speed is guaranteed non-None here: either the caller passed one (and
-        # the early-return validation above rejected bad values) or the auto
-        # branch assigned a fallback of 1.
-        effective_speed: int = speed  # type: ignore[assignment]
-
-        if direction in ("Left", "Right"):
-            deg_per_sec = get_pan_speed_per_sec(adapter, effective_speed)
-            bias = get_pan_bias(adapter, effective_speed)
-        else:
-            deg_per_sec = get_tilt_speed_per_sec(adapter, effective_speed)
-            bias = get_tilt_bias(adapter, effective_speed)
-
-        if deg_per_sec is None:
-            # Uncalibrated adapter (e.g. linovision): rough "speed≈°/s" proxy.
-            # Calibrated adapters can't reach this branch because the caller's
-            # speed was already validated against the table above, and
-            # auto-pick on an empty table yields speed=1 which also falls here.
-            try:
-                deg_per_sec = max(0.1, float(effective_speed))
-            except Exception:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"Unsupported adapter '{adapter}' or speed level {effective_speed}",
-                )
-
-        duration_sec = max(0.0, (abs(degrees) - bias) / deg_per_sec)
-        micro = duration_sec == 0.0 and abs(degrees) > 0
-        interrupted = False
-        start_azimuth = _start_azimuth_for_tracking(cam)
-
-        if micro:
-            logger.info(
-                "[%s] move_by_degrees %s %.2f° micro-impulse speed=1 (adapter=%s)",
-                camera_ip,
-                direction,
-                abs(degrees),
-                adapter,
-            )
-            cam.move_camera(direction, speed=1)
-            cam.move_camera("Stop")
-        else:
-            logger.info(
-                "[%s] move_by_degrees %s %.2f° dur=%.2fs speed=%s (adapter=%s)",
-                camera_ip,
-                direction,
-                abs(degrees),
-                duration_sec,
-                effective_speed,
-                adapter,
-            )
-            cam.move_camera(direction, speed=effective_speed)
-            interrupted = _interruptible_sleep(camera_ip, duration_sec)
-            cam.move_camera("Stop")
-
-        if not interrupted:
-            # A micro-impulse physically moves about the speed-1 coast bias.
-            moved_deg = get_pan_bias(adapter, 1) if micro else abs(degrees)
-            _update_tracked_azimuth(cam, start_azimuth, direction, moved_deg)
-
-        resp: dict = {
-            "status": "ok",
-            "camera_ip": camera_ip,
-            "direction": direction,
-            "degrees": degrees,
-            "duration": 0 if micro else round(duration_sec, 2),
-            "speed": 1 if micro else effective_speed,
-            "adapter": adapter,
-            "zoom": zoom,
-            "micro": micro,
-        }
-        if interrupted:
-            resp["interrupted"] = True
-        return resp
+        return _execute_degrees_move(cam, camera_ip, direction, degrees, speed, adapter)
     except HTTPException:
         raise
     except Exception as exc:
@@ -842,6 +720,134 @@ def move_by_degrees(
         raise HTTPException(status_code=500, detail=str(exc))
     finally:
         lock.release()
+
+
+def _execute_degrees_move(
+    cam: PTZMixin,
+    camera_ip: str,
+    direction: str,
+    degrees: float,
+    speed: Optional[int],
+    adapter: str,
+) -> dict:
+    """Core of /move_by_degrees; the caller must hold the per-camera lock."""
+    zoom = 0
+    if hasattr(cam, "get_focus_level"):
+        try:
+            info = cam.get_focus_level() or {}
+            z = info.get("zoom")
+            if z is not None:
+                zoom = int(z)
+        except Exception as exc:
+            logger.warning("[%s] move_by_degrees: failed to read zoom, assuming 0: %s", camera_ip, exc)
+
+    axis_speeds = PAN_SPEEDS.get(adapter, {}) if direction in ("Left", "Right") else TILT_SPEEDS.get(adapter, {})
+    axis_bias = PAN_BIAS.get(adapter, {}) if direction in ("Left", "Right") else TILT_BIAS.get(adapter, {})
+
+    # Reject out-of-range explicit speeds up-front rather than silently
+    # downgrading them later. The server enforces the rule that matches
+    # physical reality: at zoom 0 only calibrated levels are valid, and
+    # at zoom > 0 only speed 1 is honored by Reolink hardware.
+    if speed is not None:
+        if zoom > 0 and speed != 1:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"speed={speed} invalid at zoom={zoom}: Reolink caps all speeds "
+                    f"to speed 1 (~1.5 °/s) above zoom 0. Pass speed=1 or omit 'speed' "
+                    f"to auto-pick."
+                ),
+            )
+        if axis_speeds and speed not in axis_speeds:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"speed={speed} not in calibrated table for adapter '{adapter}' "
+                    f"(levels: {sorted(axis_speeds)}). Omit 'speed' to auto-pick."
+                ),
+            )
+
+    # Auto-pick the calibrated speed level when caller didn't specify one.
+    # _pick_speed restricts to speed 1 at zoom > 0, and may return None
+    # for angles below bias[1] — those become a micro-impulse below.
+    auto_speed = speed is None
+    if auto_speed:
+        picked = _pick_speed(abs(degrees), axis_speeds, axis_bias, zoom=zoom) if axis_speeds else None
+        speed = picked if picked is not None else 1
+
+    # speed is guaranteed non-None here: either the caller passed one (and
+    # the early-return validation above rejected bad values) or the auto
+    # branch assigned a fallback of 1.
+    effective_speed: int = speed  # type: ignore[assignment]
+
+    if direction in ("Left", "Right"):
+        deg_per_sec = get_pan_speed_per_sec(adapter, effective_speed)
+        bias = get_pan_bias(adapter, effective_speed)
+    else:
+        deg_per_sec = get_tilt_speed_per_sec(adapter, effective_speed)
+        bias = get_tilt_bias(adapter, effective_speed)
+
+    if deg_per_sec is None:
+        # Uncalibrated adapter (e.g. linovision): rough "speed≈°/s" proxy.
+        # Calibrated adapters can't reach this branch because the caller's
+        # speed was already validated against the table above, and
+        # auto-pick on an empty table yields speed=1 which also falls here.
+        try:
+            deg_per_sec = max(0.1, float(effective_speed))
+        except Exception:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported adapter '{adapter}' or speed level {effective_speed}",
+            )
+
+    duration_sec = max(0.0, (abs(degrees) - bias) / deg_per_sec)
+    micro = duration_sec == 0.0 and abs(degrees) > 0
+    interrupted = False
+    start_azimuth = _start_azimuth_for_tracking(cam)
+
+    if micro:
+        logger.info(
+            "[%s] move_by_degrees %s %.2f° micro-impulse speed=1 (adapter=%s)",
+            camera_ip,
+            direction,
+            abs(degrees),
+            adapter,
+        )
+        cam.move_camera(direction, speed=1)
+        cam.move_camera("Stop")
+    else:
+        logger.info(
+            "[%s] move_by_degrees %s %.2f° dur=%.2fs speed=%s (adapter=%s)",
+            camera_ip,
+            direction,
+            abs(degrees),
+            duration_sec,
+            effective_speed,
+            adapter,
+        )
+        cam.move_camera(direction, speed=effective_speed)
+        interrupted = _interruptible_sleep(camera_ip, duration_sec)
+        cam.move_camera("Stop")
+
+    if not interrupted:
+        # A micro-impulse physically moves about the speed-1 coast bias.
+        moved_deg = get_pan_bias(adapter, 1) if micro else abs(degrees)
+        _update_tracked_azimuth(cam, start_azimuth, direction, moved_deg)
+
+    resp: dict = {
+        "status": "ok",
+        "camera_ip": camera_ip,
+        "direction": direction,
+        "degrees": degrees,
+        "duration": 0 if micro else round(duration_sec, 2),
+        "speed": 1 if micro else effective_speed,
+        "adapter": adapter,
+        "zoom": zoom,
+        "micro": micro,
+    }
+    if interrupted:
+        resp["interrupted"] = True
+    return resp
 
 
 @router.get("/azimuth")
@@ -901,36 +907,48 @@ def move_to_azimuth(camera_ip: str, azimuth: float, speed: Optional[int] = None)
         finally:
             lock.release()
 
-    current = cam.get_azimuth()
-    if current is None:
-        raise HTTPException(
-            status_code=409,
-            detail="Camera azimuth unknown; wait for a patrol pass or call /goto_preset first",
-        )
-
-    delta = _shortest_delta_deg(current, target)
     conf = RAW_CONFIG.get(camera_ip, {})
     adapter = _resolve_adapter(conf.get("adapter", "unknown"))
 
-    # Same skip threshold as click_to_move: below half the speed-1 coast bias,
-    # a micro-impulse would overshoot more than staying put.
-    if abs(delta) < PAN_BIAS.get(adapter, {}).get(1, 1.0) / 2:
-        return {
-            "status": "ok",
-            "camera_ip": camera_ip,
-            "azimuth_deg": round(current, 2),
-            "source": "tracked",
-            "skipped": True,
-            "delta_deg": round(delta, 3),
-        }
+    # Hold one lock across the azimuth read, delta computation, and move so a
+    # concurrent command cannot make the delta stale in between.
+    lock = _acquire_or_409(camera_ip)
+    try:
+        current = cam.get_azimuth()
+        if current is None:
+            raise HTTPException(
+                status_code=409,
+                detail="Camera azimuth unknown; wait for a patrol pass or call /goto_preset first",
+            )
 
-    direction = "Right" if delta > 0 else "Left"
-    resp = move_by_degrees(camera_ip=camera_ip, direction=direction, degrees=abs(delta), speed=speed)
-    resp["source"] = "tracked"
-    resp["target_azimuth_deg"] = round(target, 2)
-    tracked = cam.get_azimuth()
-    resp["azimuth_deg"] = None if tracked is None else round(tracked, 2)
-    return resp
+        delta = _shortest_delta_deg(current, target)
+
+        # Same skip threshold as click_to_move: below half the speed-1 coast
+        # bias, a micro-impulse would overshoot more than staying put.
+        if abs(delta) < PAN_BIAS.get(adapter, {}).get(1, 1.0) / 2:
+            return {
+                "status": "ok",
+                "camera_ip": camera_ip,
+                "azimuth_deg": round(current, 2),
+                "source": "tracked",
+                "skipped": True,
+                "delta_deg": round(delta, 3),
+            }
+
+        direction = "Right" if delta > 0 else "Left"
+        resp = _execute_degrees_move(cam, camera_ip, direction, abs(delta), speed, adapter)
+        resp["source"] = "tracked"
+        resp["target_azimuth_deg"] = round(target, 2)
+        tracked = cam.get_azimuth()
+        resp["azimuth_deg"] = None if tracked is None else round(tracked, 2)
+        return resp
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("[%s] move_to_azimuth error: %s", camera_ip, exc)
+        raise HTTPException(status_code=500, detail=str(exc))
+    finally:
+        lock.release()
 
 
 @router.get("/speed_tables")

--- a/pyro_camera_api/pyro_camera_api/api/routes_control.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_control.py
@@ -508,9 +508,10 @@ def stop_camera(camera_ip: str):
         raise HTTPException(status_code=400, detail="Camera does not support PTZ controls")
 
     try:
-        cam.move_camera("Stop")
-        # Wake any blocking handler currently sleeping under the lock.
+        # Wake any blocking handler first: even if the Stop command below is
+        # rejected by the camera, the woken handler sends its own timed Stop.
         STOP_EVENTS[camera_ip].set()
+        cam.move_camera("Stop")
         logger.info("[%s] Movement stopped", camera_ip)
         return {"message": f"Camera {camera_ip} stopped moving"}
     except Exception as exc:
@@ -898,13 +899,15 @@ def move_to_azimuth(camera_ip: str, azimuth: float, speed: Optional[int] = None)
     """Move the camera to an absolute real-world azimuth in degrees.
 
     Hardware adapters (Linovision) execute a blocking absolute move. Tracked
-    adapters (Reolink) rotate by the shortest signed delta from the current
-    dead-reckoned azimuth using the calibrated speed tables, reusing the
-    /move_by_degrees semantics (auto speed pick, zoom cap, micro-impulse).
+    adapters (Reolink) first recall the preset pose whose azimuth is closest
+    to the target (fast hardware travel that also re-anchors the dead-reckoned
+    reference), then correct the small residual with a calibrated timed pan
+    (same semantics as /move_by_degrees: auto speed pick, zoom cap,
+    micro-impulse). The residual is bounded by half the inter-pose spacing,
+    so the blocking time stays click_to_move-sized even at zoom > 0.
 
-    Returns 409 when the camera is busy, or when the tracked azimuth is still
-    unknown (no preset move since boot; wait for a patrol pass or call
-    /goto_preset first).
+    Returns 409 when the camera is busy, or when the pose azimuths have not
+    been resolved from the platform API yet (no anchor available).
     """
     update_command_time()
     cam = _require_ptz(camera_ip)
@@ -932,35 +935,69 @@ def move_to_azimuth(camera_ip: str, azimuth: float, speed: Optional[int] = None)
     conf = RAW_CONFIG.get(camera_ip, {})
     adapter = _resolve_adapter(conf.get("adapter", "unknown"))
 
-    # Hold one lock across the azimuth read, delta computation, and move so a
-    # concurrent command cannot make the delta stale in between.
+    poses = list(getattr(cam, "cam_poses", []) or [])
+    azimuths = list(getattr(cam, "cam_azimuths", []) or [])
+    if not azimuths or len(azimuths) != len(poses):
+        raise HTTPException(
+            status_code=409,
+            detail="Pose azimuths not resolved from the platform API yet; cannot anchor an absolute move",
+        )
+
+    # Hold one lock across the whole anchor-then-correct sequence so a
+    # concurrent command cannot slip in between the preset recall and the
+    # residual pan.
     lock = _acquire_or_409(camera_ip)
     try:
-        current = cam.get_azimuth()
-        if current is None:
-            raise HTTPException(
-                status_code=409,
-                detail="Camera azimuth unknown; wait for a patrol pass or call /goto_preset first",
-            )
-
-        delta = _shortest_delta_deg(current, target)
-
         # Same skip threshold as click_to_move: below half the speed-1 coast
         # bias, a micro-impulse would overshoot more than staying put.
-        if abs(delta) < PAN_BIAS.get(adapter, {}).get(1, 1.0) / 2:
+        skip_threshold = PAN_BIAS.get(adapter, {}).get(1, 1.0) / 2
+        current = cam.get_azimuth()
+        if current is not None and abs(_shortest_delta_deg(current, target)) < skip_threshold:
             return {
                 "status": "ok",
                 "camera_ip": camera_ip,
                 "azimuth_deg": round(current, 2),
                 "source": "tracked",
                 "skipped": True,
-                "delta_deg": round(delta, 3),
+                "delta_deg": round(_shortest_delta_deg(current, target), 3),
             }
 
-        direction = "Right" if delta > 0 else "Left"
-        resp = _execute_degrees_move(cam, camera_ip, direction, abs(delta), speed, adapter)
-        resp["source"] = "tracked"
-        resp["target_azimuth_deg"] = round(target, 2)
+        # Anchor on the preset pose closest to the target: preset recall runs
+        # at hardware speed regardless of zoom, and re-sets the dead-reckoned
+        # reference, so drift cannot accumulate across absolute moves.
+        pose_id, pose_azimuth = min(
+            zip(poses, azimuths, strict=True),
+            key=lambda pair: abs(_shortest_delta_deg(pair[1], target)),
+        )
+        logger.info(
+            "[%s] move_to_azimuth %.2f° via pose %s (%.2f°)",
+            camera_ip,
+            target,
+            pose_id,
+            pose_azimuth,
+        )
+        cam.move_camera("ToPos", speed=50, idx=pose_id)
+        resp: dict = {
+            "status": "ok",
+            "camera_ip": camera_ip,
+            "source": "tracked",
+            "target_azimuth_deg": round(target, 2),
+            "pose_id": pose_id,
+            "pose_azimuth_deg": round(pose_azimuth, 2),
+        }
+        _hold_for_preset_move(cam, camera_ip, resp)
+        if resp.get("interrupted"):
+            resp["azimuth_deg"] = None
+            return resp
+
+        residual = _shortest_delta_deg(pose_azimuth, target)
+        if abs(residual) >= skip_threshold:
+            direction = "Right" if residual > 0 else "Left"
+            move_resp = _execute_degrees_move(cam, camera_ip, direction, abs(residual), speed, adapter)
+            resp["residual_move"] = move_resp
+            if move_resp.get("interrupted"):
+                resp["interrupted"] = True
+
         tracked = cam.get_azimuth()
         resp["azimuth_deg"] = None if tracked is None else round(tracked, 2)
         return resp

--- a/pyro_camera_api/pyro_camera_api/api/routes_control.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_control.py
@@ -860,14 +860,36 @@ def get_camera_azimuth(camera_ip: str):
     move (patrol pass or /goto_preset) provides a reference, and after an
     interrupted or untimed free move. ``moving`` reflects whether a blocking
     PTZ command currently holds the per-camera lock.
+
+    ``zoom`` and ``h_fov_deg`` describe the current field of view: the zoom
+    level is read from the camera and the horizontal FOV comes from the
+    calibrated tables (fov_at_zoom). For adapters without calibration
+    (e.g. Linovision) h_fov_deg falls back to the default table and is only
+    indicative.
     """
     cam = _require_ptz(camera_ip)
+    conf = RAW_CONFIG.get(camera_ip, {})
+    adapter = _resolve_adapter(conf.get("adapter", "unknown"))
+
+    zoom = 0
+    if hasattr(cam, "get_focus_level"):
+        try:
+            info = cam.get_focus_level() or {}
+            z = info.get("zoom")
+            if z is not None:
+                zoom = int(z)
+        except Exception as exc:
+            logger.warning("[%s] azimuth: failed to read zoom, assuming 0: %s", camera_ip, exc)
+    h_fov, _ = fov_at_zoom(zoom, adapter)
+
     azimuth = cam.get_azimuth()
     return {
         "camera_ip": camera_ip,
         "azimuth_deg": None if azimuth is None else round(azimuth, 2),
         "source": cam.azimuth_source,
         "moving": MOVE_LOCKS[camera_ip].locked(),
+        "zoom": zoom,
+        "h_fov_deg": round(h_fov, 2),
     }
 
 

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/linovision.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/linovision.py
@@ -47,7 +47,7 @@ class LinovisionCamera(BaseCamera, PTZMixin, FocusMixin):
         password: str,
         cam_type: str = "ptz",
         cam_poses: Optional[List[int]] = None,
-        cam_azimuths: Optional[List[int]] = None,
+        cam_azimuths: Optional[List[float]] = None,
         protocol: str = "http",
         verify_tls: bool = False,
         snapshot_channel: str = "101",

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/linovision.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/linovision.py
@@ -203,13 +203,6 @@ class LinovisionCamera(BaseCamera, PTZMixin, FocusMixin):
             logger.warning("[%s] Failed to read azimuth: %s", self.ip_address, exc)
             return None
 
-    def move_to_azimuth(self, azimuth_deg: float) -> dict:
-        """Move to a real-world azimuth, blocking until the camera reports it reached."""
-        return self.move_absolute_perfect(
-            azimuth_deg=self._real_to_camera_azimuth(azimuth_deg),
-            elevation_deg=self.default_elevation_deg,
-        )
-
     def wait_reached_azimuth_raw(
         self,
         target_azimuth_deg: float,

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/linovision.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/linovision.py
@@ -37,6 +37,8 @@ class LinovisionCamera(BaseCamera, PTZMixin, FocusMixin):
       camera_command_az = (real_az + azimuth_offset_deg) % 360
     """
 
+    azimuth_source = "hardware"
+
     def __init__(
         self,
         camera_id: str,
@@ -192,6 +194,21 @@ class LinovisionCamera(BaseCamera, PTZMixin, FocusMixin):
             "zoom_raw": zoom,
             "real_azimuth_deg": self._camera_to_real_azimuth(az10 / 10.0),
         }
+
+    def get_azimuth(self) -> Optional[float]:
+        """Read the current real-world azimuth from the camera's PTZ status."""
+        try:
+            return float(self.get_ptz_status()["real_azimuth_deg"])
+        except Exception as exc:
+            logger.warning("[%s] Failed to read azimuth: %s", self.ip_address, exc)
+            return None
+
+    def move_to_azimuth(self, azimuth_deg: float) -> dict:
+        """Move to a real-world azimuth, blocking until the camera reports it reached."""
+        return self.move_absolute_perfect(
+            azimuth_deg=self._real_to_camera_azimuth(azimuth_deg),
+            elevation_deg=self.default_elevation_deg,
+        )
 
     def wait_reached_azimuth_raw(
         self,

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/mock.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/mock.py
@@ -13,7 +13,7 @@ from typing import Optional
 import requests
 from PIL import Image
 
-from pyro_camera_api.camera.base import BaseCamera, FocusMixin, PTZMixin
+from pyro_camera_api.camera.base import PAN_OPERATIONS, BaseCamera, FocusMixin, PTZMixin
 
 __all__ = ["MockCamera"]
 
@@ -48,6 +48,8 @@ class MockCamera(BaseCamera, PTZMixin, FocusMixin):
         self.cam_poses = cam_poses or []
         self.cam_azimuths = cam_azimuths or []
         self.focus_position = focus_position
+        # Same dead-reckoned azimuth behavior as Reolink, for tests and demos.
+        self.current_azimuth: Optional[float] = None
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -83,6 +85,10 @@ class MockCamera(BaseCamera, PTZMixin, FocusMixin):
     # ------------------------------------------------------------------
 
     def move_camera(self, operation: str, speed: int = 20, idx: int = 0) -> None:
+        if operation in PAN_OPERATIONS:
+            self.current_azimuth = None
+        elif operation == "ToPos" and idx in self.cam_poses and len(self.cam_poses) == len(self.cam_azimuths):
+            self.current_azimuth = float(self.cam_azimuths[self.cam_poses.index(idx)]) % 360.0
         logger.info(
             "MockCamera %s move_camera called, op=%s speed=%s idx=%s (no op)",
             self.camera_id,
@@ -90,6 +96,9 @@ class MockCamera(BaseCamera, PTZMixin, FocusMixin):
             speed,
             idx,
         )
+
+    def get_azimuth(self) -> Optional[float]:
+        return self.current_azimuth
 
     # ------------------------------------------------------------------
     # FocusMixin implementation (fake but compatible)

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/mock.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/mock.py
@@ -87,8 +87,11 @@ class MockCamera(BaseCamera, PTZMixin, FocusMixin):
     def move_camera(self, operation: str, speed: int = 20, idx: int = 0) -> None:
         if operation in PAN_OPERATIONS:
             self.current_azimuth = None
-        elif operation == "ToPos" and idx in self.cam_poses and len(self.cam_poses) == len(self.cam_azimuths):
-            self.current_azimuth = float(self.cam_azimuths[self.cam_poses.index(idx)]) % 360.0
+        elif operation == "ToPos":
+            if idx in self.cam_poses and len(self.cam_poses) == len(self.cam_azimuths):
+                self.current_azimuth = float(self.cam_azimuths[self.cam_poses.index(idx)]) % 360.0
+            else:
+                self.current_azimuth = None
         logger.info(
             "MockCamera %s move_camera called, op=%s speed=%s idx=%s (no op)",
             self.camera_id,

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/mock.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/mock.py
@@ -38,7 +38,7 @@ class MockCamera(BaseCamera, PTZMixin, FocusMixin):
         image_url: str = DEFAULT_FAKE_IMAGE_URL,
         cam_type: str = "static",
         cam_poses: Optional[list[int]] = None,
-        cam_azimuths: Optional[list[int]] = None,
+        cam_azimuths: Optional[list[float]] = None,
         focus_position: Optional[int] = None,
     ) -> None:
         super().__init__(camera_id=camera_id, cam_type=cam_type)

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
@@ -60,6 +60,14 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
         self.focus_position = focus_position
         # Dead-reckoned real-world azimuth; None until a preset move gives a reference.
         self.current_azimuth: Optional[float] = None
+        if self.cam_type == "ptz" and len(self.cam_poses) != len(self.cam_azimuths):
+            logger.warning(
+                "[%s] poses (%d) and azimuths (%d) differ in credentials.json; "
+                "azimuth tracking will stay unknown until fixed",
+                self.ip_address,
+                len(self.cam_poses),
+                len(self.cam_azimuths),
+            )
 
     def _build_url(self, command: str) -> str:
         """Constructs a URL for API commands to the camera."""

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
@@ -33,6 +33,10 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
     A controller class for interacting with Reolink cameras.
     """
 
+    # ToPos is fire-and-forget with no completion feedback: hold the per-camera
+    # lock for a conservative travel time so concurrent commands get a 409.
+    preset_move_hold_s = 5.0
+
     def __init__(
         self,
         camera_id: str,
@@ -99,6 +103,9 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
     def move_camera(self, operation: str, speed: int = 20, idx: int = 0):
         """
         Sends a command to move the camera.
+
+        Raises RuntimeError when the camera rejects the command, so callers
+        (and the dead-reckoned azimuth) never assume a move that did not start.
         """
         if operation in PAN_OPERATIONS:
             # Untimed pan motion starts: azimuth is unknown until the caller
@@ -110,19 +117,25 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
         ]
         response = requests.post(url, json=data, verify=False)  # nosec: B501
         response_data = self._handle_response(response, "PTZ operation successful.")
-        if operation == "ToPos":
-            self._sync_azimuth_from_pose(int(idx), response_data)
-
-    def _sync_azimuth_from_pose(self, pose_id: int, response_data: Any) -> None:
-        """Resync the dead-reckoned azimuth from the pose mapping after an accepted ToPos."""
         try:
             ok = bool(response_data) and response_data[0]["code"] == 0
         except (KeyError, IndexError, TypeError):
             ok = False
         if not ok:
-            return
+            raise RuntimeError(f"PTZ command '{operation}' rejected by camera {self.ip_address}")
+        if operation == "ToPos":
+            self._sync_azimuth_from_pose(int(idx))
+
+    def _sync_azimuth_from_pose(self, pose_id: int) -> None:
+        """Resync the dead-reckoned azimuth from the pose mapping after an accepted ToPos.
+
+        An accepted preset outside the configured mapping still moves the
+        camera, so the previous reference becomes stale and is dropped.
+        """
         if pose_id in self.cam_poses and len(self.cam_poses) == len(self.cam_azimuths):
             self.current_azimuth = float(self.cam_azimuths[self.cam_poses.index(pose_id)]) % 360.0
+        else:
+            self.current_azimuth = None
 
     def get_azimuth(self) -> Optional[float]:
         """Return the dead-reckoned azimuth, or None when unknown."""

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
@@ -45,7 +45,7 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
         password: str,
         cam_type: str = "ptz",
         cam_poses: Optional[List[int]] = None,
-        cam_azimuths: Optional[List[int]] = None,
+        cam_azimuths: Optional[List[float]] = None,
         protocol: str = "https",
         focus_position: Optional[int] = None,
     ):
@@ -60,7 +60,10 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
         self.focus_position = focus_position
         # Dead-reckoned real-world azimuth; None until a preset move gives a reference.
         self.current_azimuth: Optional[float] = None
-        if self.cam_type == "ptz" and len(self.cam_poses) != len(self.cam_azimuths):
+        # An empty azimuth list is normal at boot: the mapping is fetched from
+        # the platform API by camera.pose_azimuths. A non-empty mismatched list
+        # is a config error that silently disables tracking, hence the warning.
+        if self.cam_type == "ptz" and self.cam_azimuths and len(self.cam_poses) != len(self.cam_azimuths):
             logger.warning(
                 "[%s] poses (%d) and azimuths (%d) differ in credentials.json; "
                 "azimuth tracking will stay unknown until fixed",

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
@@ -19,7 +19,7 @@ import requests
 import urllib3
 from PIL import Image
 
-from pyro_camera_api.camera.base import BaseCamera, FocusMixin, PTZMixin
+from pyro_camera_api.camera.base import PAN_OPERATIONS, BaseCamera, FocusMixin, PTZMixin
 
 __all__ = ["ReolinkCamera"]
 
@@ -54,6 +54,8 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
         self.cam_azimuths = cam_azimuths if cam_azimuths is not None else []
         self.protocol = protocol
         self.focus_position = focus_position
+        # Dead-reckoned real-world azimuth; None until a preset move gives a reference.
+        self.current_azimuth: Optional[float] = None
 
     def _build_url(self, command: str) -> str:
         """Constructs a URL for API commands to the camera."""
@@ -98,12 +100,33 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
         """
         Sends a command to move the camera.
         """
+        if operation in PAN_OPERATIONS:
+            # Untimed pan motion starts: azimuth is unknown until the caller
+            # computes the displacement or a preset move resyncs it.
+            self.current_azimuth = None
         url = self._build_url("PtzCtrl")
         data: Any = [
             {"cmd": "PtzCtrl", "action": 0, "param": {"channel": 0, "op": operation, "id": idx, "speed": speed}}
         ]
         response = requests.post(url, json=data, verify=False)  # nosec: B501
-        self._handle_response(response, "PTZ operation successful.")
+        response_data = self._handle_response(response, "PTZ operation successful.")
+        if operation == "ToPos":
+            self._sync_azimuth_from_pose(int(idx), response_data)
+
+    def _sync_azimuth_from_pose(self, pose_id: int, response_data: Any) -> None:
+        """Resync the dead-reckoned azimuth from the pose mapping after an accepted ToPos."""
+        try:
+            ok = bool(response_data) and response_data[0]["code"] == 0
+        except (KeyError, IndexError, TypeError):
+            ok = False
+        if not ok:
+            return
+        if pose_id in self.cam_poses and len(self.cam_poses) == len(self.cam_azimuths):
+            self.current_azimuth = float(self.cam_azimuths[self.cam_poses.index(pose_id)]) % 360.0
+
+    def get_azimuth(self) -> Optional[float]:
+        """Return the dead-reckoned azimuth, or None when unknown."""
+        return self.current_azimuth
 
     def move_in_seconds(self, s: float, operation: str = "Right", speed: int = 20, save_path: str = "im.jpg"):
         """

--- a/pyro_camera_api/pyro_camera_api/camera/base.py
+++ b/pyro_camera_api/pyro_camera_api/camera/base.py
@@ -46,12 +46,22 @@ class BaseCamera(ABC):
         ...
 
 
+# Continuous operations that involve the pan axis. Starting one of these makes
+# a dead-reckoned azimuth stale until the caller computes the displacement or a
+# preset move provides a fresh reference.
+PAN_OPERATIONS = frozenset({"Left", "Right", "UpLeft", "UpRight", "DownLeft", "DownRight"})
+
+
 class PTZMixin(ABC):
     """
     Capability mixin for cameras that support pan tilt zoom controls.
 
     Use isinstance(camera, PTZMixin) to check support.
     """
+
+    # "tracked": azimuth is dead-reckoned server-side from commanded moves.
+    # "hardware": azimuth is read back from the camera itself.
+    azimuth_source: str = "tracked"
 
     @abstractmethod
     def move_camera(self, operation: str, speed: int = 20, idx: int = 0) -> None:
@@ -63,6 +73,14 @@ class PTZMixin(ABC):
                        examples "Left", "Right", "Up", "Down", "Stop", "ToPos".
             speed: adapter specific speed value.
             idx: Preset index for operations that use a preset.
+        """
+        ...
+
+    @abstractmethod
+    def get_azimuth(self) -> Optional[float]:
+        """
+        Return the camera's current real-world azimuth in degrees [0, 360),
+        or None when unknown (e.g. after boot, before any preset move).
         """
         ...
 

--- a/pyro_camera_api/pyro_camera_api/camera/base.py
+++ b/pyro_camera_api/pyro_camera_api/camera/base.py
@@ -7,7 +7,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from PIL import Image
 
@@ -62,6 +62,12 @@ class PTZMixin(ABC):
     # "tracked": azimuth is dead-reckoned server-side from commanded moves.
     # "hardware": azimuth is read back from the camera itself.
     azimuth_source: str = "tracked"
+
+    # Local pose presets and their real-world azimuths, index-aligned. The
+    # azimuths come from credentials.json (legacy) or are fetched from the
+    # platform API at startup (see camera.pose_azimuths).
+    cam_poses: List[int]
+    cam_azimuths: List[float]
 
     # Seconds the API keeps the camera locked after a fire-and-forget preset
     # move so concurrent commands get rejected while the camera travels.

--- a/pyro_camera_api/pyro_camera_api/camera/base.py
+++ b/pyro_camera_api/pyro_camera_api/camera/base.py
@@ -63,6 +63,11 @@ class PTZMixin(ABC):
     # "hardware": azimuth is read back from the camera itself.
     azimuth_source: str = "tracked"
 
+    # Seconds the API keeps the camera locked after a fire-and-forget preset
+    # move so concurrent commands get rejected while the camera travels.
+    # 0 when the adapter blocks (or completes instantly) on preset moves.
+    preset_move_hold_s: float = 0.0
+
     @abstractmethod
     def move_camera(self, operation: str, speed: int = 20, idx: int = 0) -> None:
         """

--- a/pyro_camera_api/pyro_camera_api/camera/pose_azimuths.py
+++ b/pyro_camera_api/pyro_camera_api/camera/pose_azimuths.py
@@ -110,7 +110,7 @@ def azimuth_sync_loop(stop_flag: threading.Event) -> None:
                 logger.info(
                     "[%s] Pose azimuths resolved from platform API: %s",
                     key,
-                    dict(zip(cam.cam_poses, cam.cam_azimuths)),
+                    dict(zip(cam.cam_poses, cam.cam_azimuths, strict=True)),
                 )
 
         stop_flag.wait(RETRY_INTERVAL_S)

--- a/pyro_camera_api/pyro_camera_api/camera/pose_azimuths.py
+++ b/pyro_camera_api/pyro_camera_api/camera/pose_azimuths.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2022-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+"""Resolve the local pose -> azimuth mapping from the platform API.
+
+credentials.json no longer carries azimuths, only local pose presets and
+platform pose ids. The platform stores each pose's azimuth together with its
+``patrol_id`` (the local pose preset index), so the mapping is fetched with the
+camera's own token from ``GET /api/v1/poses/`` and applied to the adapters that
+dead-reckon their azimuth (Reolink-style). An ``azimuths`` list present in
+credentials.json still takes precedence (legacy configs).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Dict, List
+
+import requests
+
+from pyro_camera_api.camera.base import PTZMixin
+from pyro_camera_api.camera.registry import CAMERA_REGISTRY, RAW_CONFIG
+
+logger = logging.getLogger(__name__)
+
+RETRY_INTERVAL_S = 60.0
+
+
+def fetch_pose_azimuths(api_url: str, token: str, timeout: float = 10.0) -> Dict[int, float]:
+    """Fetch the authenticated camera's active poses and map patrol_id -> azimuth."""
+    url = api_url.rstrip("/") + "/api/v1/poses/"
+    resp = requests.get(url, headers={"Authorization": f"Bearer {token}"}, timeout=timeout)
+    resp.raise_for_status()
+    mapping: Dict[int, float] = {}
+    for pose in resp.json():
+        patrol_id = pose.get("patrol_id")
+        if patrol_id is None:
+            logger.warning("Pose %s has no patrol_id, skipping", pose.get("id"))
+            continue
+        mapping[int(patrol_id)] = float(pose["azimuth"]) % 360.0
+    return mapping
+
+
+def resolve_camera_azimuths(cam: PTZMixin, mapping: Dict[int, float]) -> bool:
+    """Set cam.cam_azimuths aligned with cam.cam_poses from the fetched mapping.
+
+    Returns False (and leaves the camera untouched) when any local pose has no
+    azimuth in the mapping, so a partial list can never desynchronize the
+    pose-index-based lookup used by the adapters.
+    """
+    poses = cam.cam_poses
+    missing = [p for p in poses if p not in mapping]
+    if missing:
+        logger.warning("Poses %s have no azimuth in the platform API (mapping: %s)", missing, mapping)
+        return False
+    cam.cam_azimuths = [mapping[p] for p in poses]
+    return True
+
+
+def _cameras_needing_azimuths() -> List[str]:
+    """Tracked-azimuth PTZ cameras with poses but no azimuth mapping yet."""
+    out = []
+    for key, cam in CAMERA_REGISTRY.items():
+        if not isinstance(cam, PTZMixin) or cam.azimuth_source != "tracked":
+            continue
+        if not cam.cam_poses or cam.cam_azimuths:
+            continue
+        out.append(key)
+    return out
+
+
+def azimuth_sync_loop(stop_flag: threading.Event) -> None:
+    """Background loop: fetch pose azimuths until every camera is resolved.
+
+    Runs at startup and retries every RETRY_INTERVAL_S so an unreachable
+    platform API at boot only delays azimuth availability instead of failing
+    camera registration. Exits once nothing is left to resolve.
+    """
+    api_url = os.environ.get("API_URL", "")
+    if not api_url:
+        if _cameras_needing_azimuths():
+            logger.warning("API_URL not set; pose azimuths cannot be fetched, azimuth will stay unknown")
+        return
+
+    no_token: set[str] = set()
+    while not stop_flag.is_set():
+        pending = [k for k in _cameras_needing_azimuths() if k not in no_token]
+        if not pending:
+            logger.info("Azimuth sync complete")
+            return
+
+        for key in pending:
+            cam = CAMERA_REGISTRY[key]
+            token = RAW_CONFIG.get(key, {}).get("token")
+            if not token:
+                logger.warning("[%s] No token in credentials.json; cannot fetch pose azimuths", key)
+                no_token.add(key)
+                continue
+            try:
+                mapping = fetch_pose_azimuths(api_url, token)
+            except Exception as exc:
+                logger.warning("[%s] Failed to fetch pose azimuths, will retry: %s", key, exc)
+                continue
+            if isinstance(cam, PTZMixin) and resolve_camera_azimuths(cam, mapping):
+                logger.info(
+                    "[%s] Pose azimuths resolved from platform API: %s",
+                    key,
+                    dict(zip(cam.cam_poses, cam.cam_azimuths)),
+                )
+
+        stop_flag.wait(RETRY_INTERVAL_S)

--- a/pyro_camera_api/pyro_camera_api/main.py
+++ b/pyro_camera_api/pyro_camera_api/main.py
@@ -21,6 +21,7 @@ from pyro_camera_api.api.routes_health import router as health_router
 from pyro_camera_api.api.routes_patrol import router as patrol_router
 from pyro_camera_api.api.routes_stream import router as stream_router
 from pyro_camera_api.camera.patrol import patrol_loop, static_loop
+from pyro_camera_api.camera.pose_azimuths import azimuth_sync_loop
 from pyro_camera_api.camera.registry import (
     CAMERA_REGISTRY,
     PATROL_FLAGS,
@@ -92,9 +93,16 @@ async def lifespan(app: FastAPI):
 
     threading.Thread(target=stop_stream_if_idle, daemon=True).start()
 
+    # Resolve pose azimuths from the platform API in the background (retries
+    # until the API is reachable; azimuth stays unknown in the meantime).
+    azimuth_sync_stop = threading.Event()
+    threading.Thread(target=azimuth_sync_loop, args=(azimuth_sync_stop,), daemon=True).start()
+
     try:
         yield
     finally:
+        azimuth_sync_stop.set()
+
         for cam_id, flag in PATROL_FLAGS.items():
             logger.info("Stopping loop for camera %s", cam_id)
             flag.set()

--- a/pyro_camera_api/tests/test_azimuth.py
+++ b/pyro_camera_api/tests/test_azimuth.py
@@ -1,0 +1,98 @@
+# Copyright (C) 2022-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+import pytest
+
+from pyro_camera_api.api.routes_control import _shortest_delta_deg, _update_tracked_azimuth
+from pyro_camera_api.camera.adapters.mock import MockCamera
+
+
+def _ptz_mock() -> MockCamera:
+    return MockCamera(
+        camera_id="mock",
+        cam_type="ptz",
+        cam_poses=[0, 1, 2],
+        cam_azimuths=[0, 90, 180],
+    )
+
+
+def test_azimuth_unknown_at_start():
+    cam = _ptz_mock()
+    assert cam.get_azimuth() is None
+    assert cam.azimuth_source == "tracked"
+
+
+def test_topos_sets_azimuth_from_pose_mapping():
+    cam = _ptz_mock()
+    cam.move_camera("ToPos", idx=1)
+    assert cam.get_azimuth() == 90.0
+    cam.move_camera("ToPos", idx=2)
+    assert cam.get_azimuth() == 180.0
+
+
+def test_topos_unknown_pose_keeps_azimuth():
+    cam = _ptz_mock()
+    cam.move_camera("ToPos", idx=1)
+    cam.move_camera("ToPos", idx=99)
+    assert cam.get_azimuth() == 90.0
+
+
+def test_pan_operation_invalidates_azimuth():
+    cam = _ptz_mock()
+    cam.move_camera("ToPos", idx=1)
+    cam.move_camera("Left", speed=10)
+    assert cam.get_azimuth() is None
+
+
+def test_tilt_and_zoom_keep_azimuth():
+    cam = _ptz_mock()
+    cam.move_camera("ToPos", idx=1)
+    cam.move_camera("Up", speed=10)
+    cam.move_camera("ZoomIn", speed=10)
+    cam.move_camera("Stop")
+    assert cam.get_azimuth() == 90.0
+
+
+@pytest.mark.parametrize(
+    ("current", "target", "expected"),
+    [
+        (350.0, 10.0, 20.0),
+        (10.0, 350.0, -20.0),
+        (90.0, 90.0, 0.0),
+        (0.0, 180.0, -180.0),
+        (0.0, 90.0, 90.0),
+        (180.0, 90.0, -90.0),
+    ],
+)
+def test_shortest_delta_deg(current, target, expected):
+    assert _shortest_delta_deg(current, target) == pytest.approx(expected)
+
+
+def test_update_tracked_azimuth_right_wraps():
+    cam = _ptz_mock()
+    _update_tracked_azimuth(cam, start_azimuth=350.0, direction="Right", degrees=30.0)
+    assert cam.get_azimuth() == pytest.approx(20.0)
+
+
+def test_update_tracked_azimuth_left():
+    cam = _ptz_mock()
+    _update_tracked_azimuth(cam, start_azimuth=10.0, direction="Left", degrees=30.0)
+    assert cam.get_azimuth() == pytest.approx(340.0)
+
+
+def test_update_tracked_azimuth_ignores_tilt_and_unknown_start():
+    cam = _ptz_mock()
+    _update_tracked_azimuth(cam, start_azimuth=90.0, direction="Up", degrees=30.0)
+    assert cam.get_azimuth() is None
+    _update_tracked_azimuth(cam, start_azimuth=None, direction="Right", degrees=30.0)
+    assert cam.get_azimuth() is None
+
+
+def test_update_tracked_azimuth_ignores_hardware_source():
+    cam = _ptz_mock()
+    cam.azimuth_source = "hardware"
+    _update_tracked_azimuth(cam, start_azimuth=90.0, direction="Right", degrees=30.0)
+    assert cam.current_azimuth is None

--- a/pyro_camera_api/tests/test_azimuth.py
+++ b/pyro_camera_api/tests/test_azimuth.py
@@ -5,11 +5,9 @@
 
 
 import pytest
-from fastapi import HTTPException
 
-from pyro_camera_api.api.routes_control import _shortest_delta_deg, _update_tracked_azimuth, move_to_azimuth
+from pyro_camera_api.api.routes_control import _update_tracked_azimuth
 from pyro_camera_api.camera.adapters.mock import MockCamera
-from pyro_camera_api.camera.registry import CAMERA_REGISTRY
 
 
 def _ptz_mock() -> MockCamera:
@@ -60,21 +58,6 @@ def test_tilt_and_zoom_keep_azimuth():
     assert cam.get_azimuth() == 90.0
 
 
-@pytest.mark.parametrize(
-    ("current", "target", "expected"),
-    [
-        (350.0, 10.0, 20.0),
-        (10.0, 350.0, -20.0),
-        (90.0, 90.0, 0.0),
-        (0.0, 180.0, -180.0),
-        (0.0, 90.0, 90.0),
-        (180.0, 90.0, -90.0),
-    ],
-)
-def test_shortest_delta_deg(current, target, expected):
-    assert _shortest_delta_deg(current, target) == pytest.approx(expected)
-
-
 def test_update_tracked_azimuth_right_wraps():
     cam = _ptz_mock()
     _update_tracked_azimuth(cam, start_azimuth=350.0, direction="Right", degrees=30.0)
@@ -100,62 +83,3 @@ def test_update_tracked_azimuth_ignores_hardware_source():
     cam.azimuth_source = "hardware"
     _update_tracked_azimuth(cam, start_azimuth=90.0, direction="Right", degrees=30.0)
     assert cam.current_azimuth is None
-
-
-@pytest.fixture
-def registered_cam():
-    cam = _ptz_mock()
-    CAMERA_REGISTRY["mock-azimuth-test"] = cam
-    yield cam
-    del CAMERA_REGISTRY["mock-azimuth-test"]
-
-
-def test_move_to_azimuth_409_without_pose_mapping(registered_cam):
-    registered_cam.cam_azimuths = []
-    with pytest.raises(HTTPException) as exc:
-        move_to_azimuth("mock-azimuth-test", 90.0)
-    assert exc.value.status_code == 409
-    assert "not resolved" in exc.value.detail
-
-
-@pytest.mark.usefixtures("registered_cam")
-def test_move_to_azimuth_anchors_on_closest_pose():
-    # Target 92°: pose 1 (90°) is the closest anchor, then a 2° residual pan.
-    resp = move_to_azimuth("mock-azimuth-test", 92.0, speed=5)
-    assert resp["pose_id"] == 1
-    assert resp["pose_azimuth_deg"] == 90.0
-    assert resp["residual_move"]["direction"] == "Right"
-    assert resp["azimuth_deg"] == pytest.approx(92.0)
-
-
-@pytest.mark.usefixtures("registered_cam")
-def test_move_to_azimuth_anchor_only_when_target_is_a_pose():
-    # Target exactly on a pose: no residual move needed, azimuth re-anchored.
-    resp = move_to_azimuth("mock-azimuth-test", 180.0)
-    assert resp["pose_id"] == 2
-    assert "residual_move" not in resp
-    assert resp["azimuth_deg"] == 180.0
-
-
-def test_move_to_azimuth_works_without_prior_reference(registered_cam):
-    # No preset move since boot: the pose anchor provides the reference, so
-    # the old 409 "azimuth unknown" must not happen.
-    assert registered_cam.get_azimuth() is None
-    resp = move_to_azimuth("mock-azimuth-test", 0.0)
-    assert resp["azimuth_deg"] == 0.0
-
-
-@pytest.mark.usefixtures("registered_cam")
-def test_move_to_azimuth_wraps_shortest_path():
-    # Target 358°: pose 0 (0°) is closest through the wrap, residual goes Left.
-    resp = move_to_azimuth("mock-azimuth-test", 358.0, speed=5)
-    assert resp["pose_id"] == 0
-    assert resp["residual_move"]["direction"] == "Left"
-    assert resp["azimuth_deg"] == pytest.approx(358.0)
-
-
-def test_move_to_azimuth_skips_when_already_on_target(registered_cam):
-    registered_cam.move_camera("ToPos", idx=1)
-    resp = move_to_azimuth("mock-azimuth-test", 90.2)
-    assert resp["skipped"] is True
-    assert resp["azimuth_deg"] == 90.0

--- a/pyro_camera_api/tests/test_azimuth.py
+++ b/pyro_camera_api/tests/test_azimuth.py
@@ -5,9 +5,11 @@
 
 
 import pytest
+from fastapi import HTTPException
 
-from pyro_camera_api.api.routes_control import _shortest_delta_deg, _update_tracked_azimuth
+from pyro_camera_api.api.routes_control import _shortest_delta_deg, _update_tracked_azimuth, move_to_azimuth
 from pyro_camera_api.camera.adapters.mock import MockCamera
+from pyro_camera_api.camera.registry import CAMERA_REGISTRY
 
 
 def _ptz_mock() -> MockCamera:
@@ -98,3 +100,62 @@ def test_update_tracked_azimuth_ignores_hardware_source():
     cam.azimuth_source = "hardware"
     _update_tracked_azimuth(cam, start_azimuth=90.0, direction="Right", degrees=30.0)
     assert cam.current_azimuth is None
+
+
+@pytest.fixture
+def registered_cam():
+    cam = _ptz_mock()
+    CAMERA_REGISTRY["mock-azimuth-test"] = cam
+    yield cam
+    del CAMERA_REGISTRY["mock-azimuth-test"]
+
+
+def test_move_to_azimuth_409_without_pose_mapping(registered_cam):
+    registered_cam.cam_azimuths = []
+    with pytest.raises(HTTPException) as exc:
+        move_to_azimuth("mock-azimuth-test", 90.0)
+    assert exc.value.status_code == 409
+    assert "not resolved" in exc.value.detail
+
+
+@pytest.mark.usefixtures("registered_cam")
+def test_move_to_azimuth_anchors_on_closest_pose():
+    # Target 92°: pose 1 (90°) is the closest anchor, then a 2° residual pan.
+    resp = move_to_azimuth("mock-azimuth-test", 92.0, speed=5)
+    assert resp["pose_id"] == 1
+    assert resp["pose_azimuth_deg"] == 90.0
+    assert resp["residual_move"]["direction"] == "Right"
+    assert resp["azimuth_deg"] == pytest.approx(92.0)
+
+
+@pytest.mark.usefixtures("registered_cam")
+def test_move_to_azimuth_anchor_only_when_target_is_a_pose():
+    # Target exactly on a pose: no residual move needed, azimuth re-anchored.
+    resp = move_to_azimuth("mock-azimuth-test", 180.0)
+    assert resp["pose_id"] == 2
+    assert "residual_move" not in resp
+    assert resp["azimuth_deg"] == 180.0
+
+
+def test_move_to_azimuth_works_without_prior_reference(registered_cam):
+    # No preset move since boot: the pose anchor provides the reference, so
+    # the old 409 "azimuth unknown" must not happen.
+    assert registered_cam.get_azimuth() is None
+    resp = move_to_azimuth("mock-azimuth-test", 0.0)
+    assert resp["azimuth_deg"] == 0.0
+
+
+@pytest.mark.usefixtures("registered_cam")
+def test_move_to_azimuth_wraps_shortest_path():
+    # Target 358°: pose 0 (0°) is closest through the wrap, residual goes Left.
+    resp = move_to_azimuth("mock-azimuth-test", 358.0, speed=5)
+    assert resp["pose_id"] == 0
+    assert resp["residual_move"]["direction"] == "Left"
+    assert resp["azimuth_deg"] == pytest.approx(358.0)
+
+
+def test_move_to_azimuth_skips_when_already_on_target(registered_cam):
+    registered_cam.move_camera("ToPos", idx=1)
+    resp = move_to_azimuth("mock-azimuth-test", 90.2)
+    assert resp["skipped"] is True
+    assert resp["azimuth_deg"] == 90.0

--- a/pyro_camera_api/tests/test_azimuth.py
+++ b/pyro_camera_api/tests/test_azimuth.py
@@ -33,11 +33,13 @@ def test_topos_sets_azimuth_from_pose_mapping():
     assert cam.get_azimuth() == 180.0
 
 
-def test_topos_unknown_pose_keeps_azimuth():
+def test_topos_unmapped_pose_invalidates_azimuth():
+    # An accepted preset outside the mapping still moves the camera, so the
+    # previous reference is stale and must be dropped.
     cam = _ptz_mock()
     cam.move_camera("ToPos", idx=1)
     cam.move_camera("ToPos", idx=99)
-    assert cam.get_azimuth() == 90.0
+    assert cam.get_azimuth() is None
 
 
 def test_pan_operation_invalidates_azimuth():

--- a/pyro_camera_api/tests/test_pose_azimuths.py
+++ b/pyro_camera_api/tests/test_pose_azimuths.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2022-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pyro_camera_api.camera.adapters.mock import MockCamera
+from pyro_camera_api.camera.pose_azimuths import fetch_pose_azimuths, resolve_camera_azimuths
+
+
+def _response(json_body, status=200):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_body
+    if status >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+API_POSES = [
+    {"id": 277, "camera_id": 11, "azimuth": 10.0, "patrol_id": 0, "active": True},
+    {"id": 156, "camera_id": 11, "azimuth": 75.5, "patrol_id": 1, "active": True},
+    {"id": 281, "camera_id": 11, "azimuth": 140.0, "patrol_id": 2, "active": True},
+    {"id": 999, "camera_id": 11, "azimuth": 200.0, "patrol_id": None, "active": True},
+]
+
+
+def test_fetch_pose_azimuths_maps_patrol_id():
+    with patch("pyro_camera_api.camera.pose_azimuths.requests.get", return_value=_response(API_POSES)) as get:
+        mapping = fetch_pose_azimuths("https://api.example.org", "tok")
+    assert mapping == {0: 10.0, 1: 75.5, 2: 140.0}  # pose without patrol_id is skipped
+    url = get.call_args[0][0]
+    assert url == "https://api.example.org/api/v1/poses/"
+    assert get.call_args.kwargs["headers"] == {"Authorization": "Bearer tok"}
+
+
+def test_fetch_pose_azimuths_wraps_azimuth():
+    poses = [{"id": 1, "azimuth": 360.0, "patrol_id": 0}]
+    with patch("pyro_camera_api.camera.pose_azimuths.requests.get", return_value=_response(poses)):
+        assert fetch_pose_azimuths("https://api.example.org", "tok") == {0: 0.0}
+
+
+def test_fetch_pose_azimuths_raises_on_http_error():
+    with (
+        patch("pyro_camera_api.camera.pose_azimuths.requests.get", return_value=_response([], status=401)),
+        pytest.raises(Exception, match="HTTP 401"),
+    ):
+        fetch_pose_azimuths("https://api.example.org", "bad-token")
+
+
+def test_resolve_camera_azimuths_aligns_with_poses():
+    cam = MockCamera(camera_id="mock", cam_type="ptz", cam_poses=[0, 2, 1])
+    assert resolve_camera_azimuths(cam, {0: 10.0, 1: 75.5, 2: 140.0})
+    assert cam.cam_azimuths == [10.0, 140.0, 75.5]
+    # The pose sync now produces a value
+    cam.move_camera("ToPos", idx=2)
+    assert cam.get_azimuth() == 140.0
+
+
+def test_resolve_camera_azimuths_rejects_partial_mapping():
+    cam = MockCamera(camera_id="mock", cam_type="ptz", cam_poses=[0, 1, 5])
+    assert not resolve_camera_azimuths(cam, {0: 10.0, 1: 75.5})
+    assert cam.cam_azimuths == []


### PR DESCRIPTION
- Reolink cameras cannot report their azimuth, so the platform loses orientation during live streams. This adds server-side dead reckoning: preset moves (patrol or `/goto_preset`) provide the reference from the pose/azimuth mapping, and calibrated timed pan moves update it incrementally. Linovision reads azimuth from hardware.
- The pose/azimuth mapping is fetched from the platform API at startup (`GET /api/v1/poses/` with the camera token, mapped by `patrol_id`), with retries until the API is reachable. A legacy `azimuths` list in `credentials.json` still takes precedence.
- New endpoint: `GET /control/azimuth` (current value, source, moving flag, zoom level and calibrated horizontal FOV for the cone opening).
- Preset moves now hold the per-camera lock while fire-and-forget adapters travel, so concurrent PTZ commands get a 409 instead of corrupting the estimate; untimed free moves and `/stop` interruptions invalidate it until the next preset move.
- Known limitation: the patrol loop drives cameras outside the lock; the platform must stop patrol before manual control (as today).

Note: a `POST /control/move_to_azimuth` endpoint (absolute move anchored on the closest preset pose) was initially part of this PR but was moved out to keep the scope on azimuth tracking for live sessions; it will come back in a follow-up PR.
