### PR TITLE
fix(deps): bump pyroclient to a revision supporting recorded_at

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,1 +1,1 @@
-pyroclient @ git+https://github.com/pyronear/pyro-api.git@2f4a08ad39b313982051f178b11070d6f9b1165f#subdirectory=client
+pyroclient @ git+https://github.com/pyronear/pyro-api.git@5c73e72ec86b9a84bc088dded28f19b2cb58282a#subdirectory=client

--- a/uv.lock
+++ b/uv.lock
@@ -1158,7 +1158,7 @@ requires-dist = [
 [[package]]
 name = "pyroclient"
 version = "0.2.0.dev0"
-source = { git = "https://github.com/pyronear/pyro-api.git?subdirectory=client&rev=main#2f4a08ad39b313982051f178b11070d6f9b1165f" }
+source = { git = "https://github.com/pyronear/pyro-api.git?subdirectory=client&rev=main#5c73e72ec86b9a84bc088dded28f19b2cb58282a" }
 dependencies = [
     { name = "requests" },
 ]


### PR DESCRIPTION
Since #386 the engine sends recorded_at on detection upload, but pyroclient
stayed pinned to v1.0.6, whose create_detection has no such parameter.

- On device (pyro-engine:1.0.14) this raises TypeError in _process_alerts.
  The exception is not caught by the handler in engine.py, so it propagates to
  core.py and no alert is ever uploaded. The queue keeps replaying the failure.
- The deployed backend (alert-api:1.0.9) already accepts recorded_at, so this is
  purely a stale client pin on the engine side.
- Bumps pyroclient from 2f4a08a to 5c73e72 in uv.lock and requirements-git.txt
  via uv lock --upgrade-package pyroclient plus the Makefile lock export step.
  No code change, requirements.txt untouched.