### PR TITLE
feat(camera): live stream aborts the running autofocus search

### DIFF
--- a/pyro_camera_api/pyro_camera_api/api/routes_focus.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_focus.py
@@ -13,8 +13,9 @@ logger = logging.getLogger(__name__)
 
 from fastapi import APIRouter, HTTPException
 
-from pyro_camera_api.camera.base import FocusMixin, PTZMixin
-from pyro_camera_api.camera.registry import CAMERA_REGISTRY
+from pyro_camera_api.camera.base import FocusAbortedError, FocusMixin, PTZMixin
+from pyro_camera_api.camera.focus_manager import focus_abort_requested, stream_is_active
+from pyro_camera_api.camera.registry import CAMERA_REGISTRY, MOVE_LOCKS
 from pyro_camera_api.utils.time_utils import update_command_time
 
 router = APIRouter()
@@ -108,6 +109,11 @@ def run_focus_optimization(camera_ip: str, save_images: bool = False):
     preset before the optimization step when available.
     The optional `save_images` parameter allows storing captured frames generated
     during the autofocus process.
+
+    Live streaming has priority: the search is refused (409) while a stream is
+    active, and a stream started mid-search aborts it (409). The per-camera
+    move lock is held for the whole search so stream startup can wait for a
+    clean abort (409 when the camera is already busy).
     """
     update_command_time()
 
@@ -121,17 +127,35 @@ def run_focus_optimization(camera_ip: str, save_images: bool = False):
     if getattr(cam, "cam_type", "static") == "static":
         raise HTTPException(status_code=400, detail="Autofocus is not supported for static cameras")
 
-    if isinstance(cam, PTZMixin):
-        cam_poses = getattr(cam, "cam_poses", None)
-        if cam_poses and len(cam_poses) > 1:
-            pose1 = cam_poses[1]
-            try:
-                cam.move_camera("ToPos", idx=pose1, speed=50)
-                time.sleep(1)
-            except Exception as exc:
-                logger.warning("Could not move camera to pose %s before focus: %s", pose1, exc)
+    if stream_is_active(camera_ip):
+        raise HTTPException(status_code=409, detail="Stream active, focus optimization refused")
 
-    best_position = cam.focus_finder(save_images=save_images)
+    lock = MOVE_LOCKS[camera_ip]
+    if not lock.acquire(blocking=False):
+        raise HTTPException(status_code=409, detail="Camera busy, focus optimization refused")
+    try:
+        # Re-check under the lock: a stream may have started in between
+        if focus_abort_requested(camera_ip):
+            raise HTTPException(status_code=409, detail="Stream active, focus optimization refused")
+
+        if isinstance(cam, PTZMixin):
+            cam_poses = getattr(cam, "cam_poses", None)
+            if cam_poses and len(cam_poses) > 1:
+                pose1 = cam_poses[1]
+                try:
+                    cam.move_camera("ToPos", idx=pose1, speed=50)
+                    time.sleep(1)
+                except Exception as exc:
+                    logger.warning("Could not move camera to pose %s before focus: %s", pose1, exc)
+
+        best_position = cam.focus_finder(
+            save_images=save_images,
+            should_abort=lambda: focus_abort_requested(camera_ip),
+        )
+    except FocusAbortedError:
+        raise HTTPException(status_code=409, detail="Focus search aborted, stream has priority")
+    finally:
+        lock.release()
 
     return {
         "camera_ip": camera_ip,

--- a/pyro_camera_api/pyro_camera_api/api/routes_stream.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_stream.py
@@ -32,6 +32,12 @@ from pyro_camera_api.utils.time_utils import update_command_time
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+# Serializes stream startup: without it, two concurrent start_stream calls
+# can both pass the idempotent check and spawn two pipelines for the same
+# camera. The untracked duplicate keeps streaming invisibly, so stream-aware
+# guards (focus, patrol) believe no stream is running.
+_START_STREAM_LOCK = threading.Lock()
+
 
 @router.post("/start_stream/{camera_ip}")
 def start_stream(camera_ip: str, request: Request):
@@ -53,93 +59,94 @@ def start_stream(camera_ip: str, request: Request):
     if camera_ip not in STREAMS:
         raise HTTPException(status_code=404, detail=f"No stream config for camera {camera_ip}")
 
-    app = request.app
-    workers = get_workers(app)
-    procs = get_processes(app)
+    with _START_STREAM_LOCK:
+        app = request.app
+        workers = get_workers(app)
+        procs = get_processes(app)
 
-    # idempotent if already running
-    if is_pipeline_running(workers.get(camera_ip)) or is_process_running(procs.get(camera_ip)):
-        logger.info("Stream for %s already running", camera_ip)
-        return {"message": f"Stream for {camera_ip} already running"}
+        # idempotent if already running
+        if is_pipeline_running(workers.get(camera_ip)) or is_process_running(procs.get(camera_ip)):
+            logger.info("Stream for %s already running", camera_ip)
+            return {"message": f"Stream for {camera_ip} already running"}
 
-    stopped_cam = stop_any_running_stream(app)
+        stopped_cam = stop_any_running_stream(app)
 
-    # Abort any running focus search on this camera and wait for it to release
-    # the move lock, so the viewer never sees a sweep or a lens restoration.
-    if not cancel_focus_and_wait(camera_ip):
-        raise HTTPException(
-            status_code=409,
-            detail=f"Focus operation still running on {camera_ip}, retry in a few seconds",
-        )
-
-    # The cancel event stays set after cancel_focus_and_wait so no new focus
-    # search can sneak in before the pipeline below is registered as active.
-    # It must be cleared on every exit path once the stream is visible (or
-    # startup failed), otherwise autofocus would be blocked forever.
-    try:
-        cfg_stream = STREAMS[camera_ip]
-        input_url: str = cfg_stream["input_url"]
-        output_url: str = cfg_stream["output_url"]
-
-        anonym_cfg = RAW_CONFIG.get(camera_ip, {})
-        anonym_enabled: bool = bool(anonym_cfg.get("anonymizer", False))
-
-        # anonymizer mode
-        if anonym_enabled:
-            frames, boxes, anonym = get_stores(app)
-
-            width: int = int(cfg_stream.get("width", 640))
-            height: int = int(cfg_stream.get("height", 360))
-            fps: int = int(cfg_stream.get("fps", 10))
-            rtsp_transport: str = cfg_stream.get("rtsp_transport", "tcp")
-
-            try:
-                anonym._conf = float(cfg_stream.get("conf", getattr(anonym, "_conf", 0.35)))
-            except Exception as exc:
-                logger.warning("Failed to parse conf from stream config, using default: %s", exc)
-
-            decoder = RTSPDecoderWorker(
-                rtsp_url=input_url,
-                width=width,
-                height=height,
-                fps=fps,
-                rtsp_transport=rtsp_transport,
-                store=frames,
-            )
-            encoder = EncoderWorker(
-                frame_store=frames,
-                box_store=boxes,
-                width=width,
-                height=height,
-                srt_out=output_url,
-                target_fps=fps,
+        # Abort any running focus search on this camera and wait for it to release
+        # the move lock, so the viewer never sees a sweep or a lens restoration.
+        if not cancel_focus_and_wait(camera_ip):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Focus operation still running on {camera_ip}, retry in a few seconds",
             )
 
-            workers[camera_ip] = Pipeline(decoder=decoder, encoder=encoder)
-            logger.info("[%s] start pipeline, rtsp %s, srt %s", camera_ip, input_url, output_url)
-            decoder.start()
-            encoder.start()
+        # The cancel event stays set after cancel_focus_and_wait so no new focus
+        # search can sneak in before the pipeline below is registered as active.
+        # It must be cleared on every exit path once the stream is visible (or
+        # startup failed), otherwise autofocus would be blocked forever.
+        try:
+            cfg_stream = STREAMS[camera_ip]
+            input_url: str = cfg_stream["input_url"]
+            output_url: str = cfg_stream["output_url"]
+
+            anonym_cfg = RAW_CONFIG.get(camera_ip, {})
+            anonym_enabled: bool = bool(anonym_cfg.get("anonymizer", False))
+
+            # anonymizer mode
+            if anonym_enabled:
+                frames, boxes, anonym = get_stores(app)
+
+                width: int = int(cfg_stream.get("width", 640))
+                height: int = int(cfg_stream.get("height", 360))
+                fps: int = int(cfg_stream.get("fps", 10))
+                rtsp_transport: str = cfg_stream.get("rtsp_transport", "tcp")
+
+                try:
+                    anonym._conf = float(cfg_stream.get("conf", getattr(anonym, "_conf", 0.35)))
+                except Exception as exc:
+                    logger.warning("Failed to parse conf from stream config, using default: %s", exc)
+
+                decoder = RTSPDecoderWorker(
+                    rtsp_url=input_url,
+                    width=width,
+                    height=height,
+                    fps=fps,
+                    rtsp_transport=rtsp_transport,
+                    store=frames,
+                )
+                encoder = EncoderWorker(
+                    frame_store=frames,
+                    box_store=boxes,
+                    width=width,
+                    height=height,
+                    srt_out=output_url,
+                    target_fps=fps,
+                )
+
+                workers[camera_ip] = Pipeline(decoder=decoder, encoder=encoder)
+                logger.info("[%s] start pipeline, rtsp %s, srt %s", camera_ip, input_url, output_url)
+                decoder.start()
+                encoder.start()
+
+                return {
+                    "message": f"Stream started for {camera_ip}",
+                    "previous_stream": stopped_cam or "None",
+                    "mode": "anonymizer",
+                }
+
+            # restream mode
+            cmd = build_ffmpeg_restream_cmd(input_url=input_url, output_url=output_url)
+            logger.info("[%s] Running ffmpeg command, %s", camera_ip, " ".join(cmd))
+            proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+            procs[camera_ip] = proc
+            threading.Thread(target=log_ffmpeg_output, args=(proc, camera_ip), daemon=True).start()
 
             return {
                 "message": f"Stream started for {camera_ip}",
                 "previous_stream": stopped_cam or "None",
-                "mode": "anonymizer",
+                "mode": "restream",
             }
-
-        # restream mode
-        cmd = build_ffmpeg_restream_cmd(input_url=input_url, output_url=output_url)
-        logger.info("[%s] Running ffmpeg command, %s", camera_ip, " ".join(cmd))
-        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-        procs[camera_ip] = proc
-        threading.Thread(target=log_ffmpeg_output, args=(proc, camera_ip), daemon=True).start()
-
-        return {
-            "message": f"Stream started for {camera_ip}",
-            "previous_stream": stopped_cam or "None",
-            "mode": "restream",
-        }
-    finally:
-        FOCUS_CANCEL_EVENTS[camera_ip].clear()
+        finally:
+            FOCUS_CANCEL_EVENTS[camera_ip].clear()
 
 
 @router.post("/stop_stream")

--- a/pyro_camera_api/pyro_camera_api/api/routes_stream.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_stream.py
@@ -12,6 +12,7 @@ import threading
 
 from fastapi import APIRouter, HTTPException, Request
 
+from pyro_camera_api.camera.focus_manager import cancel_focus_and_wait
 from pyro_camera_api.camera.registry import CAMERA_REGISTRY
 from pyro_camera_api.core.config import RAW_CONFIG, STREAMS
 from pyro_camera_api.services.anonymizer_rtsp import EncoderWorker, RTSPDecoderWorker
@@ -62,6 +63,14 @@ def start_stream(camera_ip: str, request: Request):
         return {"message": f"Stream for {camera_ip} already running"}
 
     stopped_cam = stop_any_running_stream(app)
+
+    # Abort any running focus search on this camera and wait for it to release
+    # the move lock, so the viewer never sees a sweep or a lens restoration.
+    if not cancel_focus_and_wait(camera_ip):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Focus operation still running on {camera_ip}, retry in a few seconds",
+        )
 
     cfg_stream = STREAMS[camera_ip]
     input_url: str = cfg_stream["input_url"]

--- a/pyro_camera_api/pyro_camera_api/api/routes_stream.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_stream.py
@@ -69,10 +69,10 @@ def start_stream(camera_ip: str, request: Request):
             logger.info("Stream for %s already running", camera_ip)
             return {"message": f"Stream for {camera_ip} already running"}
 
-        stopped_cam = stop_any_running_stream(app)
-
         # Abort any running focus search on this camera and wait for it to release
         # the move lock, so the viewer never sees a sweep or a lens restoration.
+        # Done before stopping the current stream: on timeout we return 409 without
+        # having torn down a stream that was working on another camera.
         if not cancel_focus_and_wait(camera_ip):
             raise HTTPException(
                 status_code=409,
@@ -84,6 +84,7 @@ def start_stream(camera_ip: str, request: Request):
         # It must be cleared on every exit path once the stream is visible (or
         # startup failed), otherwise autofocus would be blocked forever.
         try:
+            stopped_cam = stop_any_running_stream(app)
             cfg_stream = STREAMS[camera_ip]
             input_url: str = cfg_stream["input_url"]
             output_url: str = cfg_stream["output_url"]

--- a/pyro_camera_api/pyro_camera_api/api/routes_stream.py
+++ b/pyro_camera_api/pyro_camera_api/api/routes_stream.py
@@ -13,7 +13,7 @@ import threading
 from fastapi import APIRouter, HTTPException, Request
 
 from pyro_camera_api.camera.focus_manager import cancel_focus_and_wait
-from pyro_camera_api.camera.registry import CAMERA_REGISTRY
+from pyro_camera_api.camera.registry import CAMERA_REGISTRY, FOCUS_CANCEL_EVENTS
 from pyro_camera_api.core.config import RAW_CONFIG, STREAMS
 from pyro_camera_api.services.anonymizer_rtsp import EncoderWorker, RTSPDecoderWorker
 from pyro_camera_api.services.stream import (
@@ -72,67 +72,74 @@ def start_stream(camera_ip: str, request: Request):
             detail=f"Focus operation still running on {camera_ip}, retry in a few seconds",
         )
 
-    cfg_stream = STREAMS[camera_ip]
-    input_url: str = cfg_stream["input_url"]
-    output_url: str = cfg_stream["output_url"]
+    # The cancel event stays set after cancel_focus_and_wait so no new focus
+    # search can sneak in before the pipeline below is registered as active.
+    # It must be cleared on every exit path once the stream is visible (or
+    # startup failed), otherwise autofocus would be blocked forever.
+    try:
+        cfg_stream = STREAMS[camera_ip]
+        input_url: str = cfg_stream["input_url"]
+        output_url: str = cfg_stream["output_url"]
 
-    anonym_cfg = RAW_CONFIG.get(camera_ip, {})
-    anonym_enabled: bool = bool(anonym_cfg.get("anonymizer", False))
+        anonym_cfg = RAW_CONFIG.get(camera_ip, {})
+        anonym_enabled: bool = bool(anonym_cfg.get("anonymizer", False))
 
-    # anonymizer mode
-    if anonym_enabled:
-        frames, boxes, anonym = get_stores(app)
+        # anonymizer mode
+        if anonym_enabled:
+            frames, boxes, anonym = get_stores(app)
 
-        width: int = int(cfg_stream.get("width", 640))
-        height: int = int(cfg_stream.get("height", 360))
-        fps: int = int(cfg_stream.get("fps", 10))
-        rtsp_transport: str = cfg_stream.get("rtsp_transport", "tcp")
+            width: int = int(cfg_stream.get("width", 640))
+            height: int = int(cfg_stream.get("height", 360))
+            fps: int = int(cfg_stream.get("fps", 10))
+            rtsp_transport: str = cfg_stream.get("rtsp_transport", "tcp")
 
-        try:
-            anonym._conf = float(cfg_stream.get("conf", getattr(anonym, "_conf", 0.35)))
-        except Exception as exc:
-            logger.warning("Failed to parse conf from stream config, using default: %s", exc)
+            try:
+                anonym._conf = float(cfg_stream.get("conf", getattr(anonym, "_conf", 0.35)))
+            except Exception as exc:
+                logger.warning("Failed to parse conf from stream config, using default: %s", exc)
 
-        decoder = RTSPDecoderWorker(
-            rtsp_url=input_url,
-            width=width,
-            height=height,
-            fps=fps,
-            rtsp_transport=rtsp_transport,
-            store=frames,
-        )
-        encoder = EncoderWorker(
-            frame_store=frames,
-            box_store=boxes,
-            width=width,
-            height=height,
-            srt_out=output_url,
-            target_fps=fps,
-        )
+            decoder = RTSPDecoderWorker(
+                rtsp_url=input_url,
+                width=width,
+                height=height,
+                fps=fps,
+                rtsp_transport=rtsp_transport,
+                store=frames,
+            )
+            encoder = EncoderWorker(
+                frame_store=frames,
+                box_store=boxes,
+                width=width,
+                height=height,
+                srt_out=output_url,
+                target_fps=fps,
+            )
 
-        workers[camera_ip] = Pipeline(decoder=decoder, encoder=encoder)
-        logger.info("[%s] start pipeline, rtsp %s, srt %s", camera_ip, input_url, output_url)
-        decoder.start()
-        encoder.start()
+            workers[camera_ip] = Pipeline(decoder=decoder, encoder=encoder)
+            logger.info("[%s] start pipeline, rtsp %s, srt %s", camera_ip, input_url, output_url)
+            decoder.start()
+            encoder.start()
+
+            return {
+                "message": f"Stream started for {camera_ip}",
+                "previous_stream": stopped_cam or "None",
+                "mode": "anonymizer",
+            }
+
+        # restream mode
+        cmd = build_ffmpeg_restream_cmd(input_url=input_url, output_url=output_url)
+        logger.info("[%s] Running ffmpeg command, %s", camera_ip, " ".join(cmd))
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        procs[camera_ip] = proc
+        threading.Thread(target=log_ffmpeg_output, args=(proc, camera_ip), daemon=True).start()
 
         return {
             "message": f"Stream started for {camera_ip}",
             "previous_stream": stopped_cam or "None",
-            "mode": "anonymizer",
+            "mode": "restream",
         }
-
-    # restream mode
-    cmd = build_ffmpeg_restream_cmd(input_url=input_url, output_url=output_url)
-    logger.info("[%s] Running ffmpeg command, %s", camera_ip, " ".join(cmd))
-    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
-    procs[camera_ip] = proc
-    threading.Thread(target=log_ffmpeg_output, args=(proc, camera_ip), daemon=True).start()
-
-    return {
-        "message": f"Stream started for {camera_ip}",
-        "previous_stream": stopped_cam or "None",
-        "mode": "restream",
-    }
+    finally:
+        FOCUS_CANCEL_EVENTS[camera_ip].clear()
 
 
 @router.post("/stop_stream")

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/linovision.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/linovision.py
@@ -10,7 +10,7 @@ import logging
 import time
 import xml.etree.ElementTree as ET
 from io import BytesIO
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import requests
 import urllib3
@@ -539,9 +539,15 @@ class LinovisionCamera(BaseCamera, PTZMixin, FocusMixin):
         )
         return {"zoom_raw": z}
 
-    def focus_finder(self, save_images: bool = False, retry_depth: int = 0) -> int:
+    def focus_finder(
+        self,
+        save_images: bool = False,
+        retry_depth: int = 0,
+        should_abort: Optional[Callable[[], bool]] = None,
+    ) -> int:
         _ = save_images
         _ = retry_depth
+        _ = should_abort
         logger.warning("Focus finder not implemented for Linovision")
         return self.focus_position if self.focus_position is not None else -1
 

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/mock.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/mock.py
@@ -8,12 +8,12 @@ from __future__ import annotations
 
 import logging
 from io import BytesIO
-from typing import Optional
+from typing import Callable, Optional
 
 import requests
 from PIL import Image
 
-from pyro_camera_api.camera.base import PAN_OPERATIONS, BaseCamera, FocusMixin, PTZMixin
+from pyro_camera_api.camera.base import PAN_OPERATIONS, BaseCamera, FocusAbortedError, FocusMixin, PTZMixin
 
 __all__ = ["MockCamera"]
 
@@ -111,9 +111,17 @@ class MockCamera(BaseCamera, PTZMixin, FocusMixin):
         self.focus_position = position
         logger.info("MockCamera %s set_manual_focus(%s) (no op)", self.camera_id, position)
 
-    def focus_finder(self, save_images: bool = False, retry_depth: int = 0) -> int:
+    def focus_finder(
+        self,
+        save_images: bool = False,
+        retry_depth: int = 0,
+        should_abort: Optional[Callable[[], bool]] = None,
+    ) -> int:
         _ = save_images
         _ = retry_depth
+        if should_abort is not None and should_abort():
+            logger.info("MockCamera %s focus_finder aborted (fake)", self.camera_id)
+            raise FocusAbortedError
         if self.focus_position is None:
             self.focus_position = 720
         logger.info("MockCamera %s focus_finder -> %s (fake)", self.camera_id, self.focus_position)

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
@@ -338,7 +338,10 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
             current_focus = self.focus_position
             logger.info("[%s] Using existing focus position: %s", self.ip_address, current_focus)
 
-        start_focus = clamp_focus(int(current_focus))
+        # Kept unclamped: a configured focus outside the search interval must
+        # be restored as-is when the search is aborted
+        pre_search_focus = int(current_focus)
+        start_focus = clamp_focus(pre_search_focus)
 
         try:
             best_focus = start_focus
@@ -384,11 +387,11 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
                             improved = True
                             break
         except FocusAbortedError:
-            logger.info("[%s] Focus search aborted, restoring pre-search focus %s", self.ip_address, start_focus)
+            logger.info("[%s] Focus search aborted, restoring pre-search focus %s", self.ip_address, pre_search_focus)
             try:
-                self.set_manual_focus(start_focus)
+                self.set_manual_focus(pre_search_focus)
             except Exception as exc:
-                logger.warning("[%s] Could not restore focus %s: %s", self.ip_address, start_focus, exc)
+                logger.warning("[%s] Could not restore focus %s: %s", self.ip_address, pre_search_focus, exc)
             # An aborted search must not leave a partial-sweep position as the
             # reference the patrol restores after every round
             self.focus_position = initial_reference

--- a/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
+++ b/pyro_camera_api/pyro_camera_api/camera/adapters/reolink.py
@@ -11,7 +11,7 @@ import operator
 import pathlib
 import time
 from io import BytesIO
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional
 
 import cv2
 import numpy as np
@@ -19,7 +19,7 @@ import requests
 import urllib3
 from PIL import Image
 
-from pyro_camera_api.camera.base import PAN_OPERATIONS, BaseCamera, FocusMixin, PTZMixin
+from pyro_camera_api.camera.base import PAN_OPERATIONS, BaseCamera, FocusAbortedError, FocusMixin, PTZMixin
 
 __all__ = ["ReolinkCamera"]
 
@@ -282,9 +282,18 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
         laplacian = cv2.Laplacian(arr, cv2.CV_64F)
         return float(laplacian.var())
 
-    def focus_finder(self, save_images: bool = False, retry_depth: int = 0) -> int:
+    def focus_finder(
+        self,
+        save_images: bool = False,
+        retry_depth: int = 0,
+        should_abort: Optional[Callable[[], bool]] = None,
+    ) -> int:
         """
         Perform adaptive exponential hill climb to find best manual focus.
+
+        should_abort is polled before each focus move; when it fires the
+        search stops, the pre-search focus is restored and FocusAbortedError
+        is raised so the caller does not treat a partial sweep as a result.
         """
         _ = retry_depth  # unused, kept for signature compatibility
 
@@ -296,6 +305,8 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
 
         def capture_and_score(pos: int) -> float:
             pos = clamp_focus(pos)
+            if should_abort is not None and should_abort():
+                raise FocusAbortedError
             self.set_manual_focus(pos)
             time.sleep(2)
             image = self.capture()
@@ -313,6 +324,10 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
         if self.cam_type == "static":
             return 720
 
+        # set_manual_focus records every probed position in focus_position, so
+        # the pre-search reference must be captured before the first probe
+        initial_reference = self.focus_position
+
         if self.focus_position is None:
             self.start_zoom_focus(0)
             time.sleep(0.5)
@@ -323,48 +338,61 @@ class ReolinkCamera(BaseCamera, PTZMixin, FocusMixin):
             current_focus = self.focus_position
             logger.info("[%s] Using existing focus position: %s", self.ip_address, current_focus)
 
-        best_focus = clamp_focus(int(current_focus))
-        best_score = capture_and_score(best_focus)
+        start_focus = clamp_focus(int(current_focus))
 
-        forward_score = capture_and_score(best_focus + 1)
-        backward_score = capture_and_score(best_focus - 1)
+        try:
+            best_focus = start_focus
+            best_score = capture_and_score(best_focus)
 
-        if forward_score > backward_score:
-            direction = 1
-            next_focus = best_focus + 1
-            next_score = forward_score
-        else:
-            direction = -1
-            next_focus = best_focus - 1
-            next_score = backward_score
+            forward_score = capture_and_score(best_focus + 1)
+            backward_score = capture_and_score(best_focus - 1)
 
-        step = 2
-        history = [(best_focus, best_score), (next_focus, next_score)]
-
-        while True:
-            test_focus = clamp_focus(next_focus + direction * step)
-            score = capture_and_score(test_focus)
-            history.append((test_focus, score))
-            if score > next_score:
-                next_focus = test_focus
-                next_score = score
-                step *= 2
+            if forward_score > backward_score:
+                direction = 1
+                next_focus = best_focus + 1
+                next_score = forward_score
             else:
-                break
+                direction = -1
+                next_focus = best_focus - 1
+                next_score = backward_score
 
-        best_focus, best_score = max(history, key=operator.itemgetter(1))
-        for fine_step in [3, 1]:
-            improved = True
-            while improved:
-                improved = False
-                for offset in (-fine_step, fine_step):
-                    candidate = clamp_focus(best_focus + offset)
-                    score = capture_and_score(candidate)
-                    if score > best_score:
-                        best_score = score
-                        best_focus = candidate
-                        improved = True
-                        break
+            step = 2
+            history = [(best_focus, best_score), (next_focus, next_score)]
+
+            while True:
+                test_focus = clamp_focus(next_focus + direction * step)
+                score = capture_and_score(test_focus)
+                history.append((test_focus, score))
+                if score > next_score:
+                    next_focus = test_focus
+                    next_score = score
+                    step *= 2
+                else:
+                    break
+
+            best_focus, best_score = max(history, key=operator.itemgetter(1))
+            for fine_step in [3, 1]:
+                improved = True
+                while improved:
+                    improved = False
+                    for offset in (-fine_step, fine_step):
+                        candidate = clamp_focus(best_focus + offset)
+                        score = capture_and_score(candidate)
+                        if score > best_score:
+                            best_score = score
+                            best_focus = candidate
+                            improved = True
+                            break
+        except FocusAbortedError:
+            logger.info("[%s] Focus search aborted, restoring pre-search focus %s", self.ip_address, start_focus)
+            try:
+                self.set_manual_focus(start_focus)
+            except Exception as exc:
+                logger.warning("[%s] Could not restore focus %s: %s", self.ip_address, start_focus, exc)
+            # An aborted search must not leave a partial-sweep position as the
+            # reference the patrol restores after every round
+            self.focus_position = initial_reference
+            raise
 
         self.focus_position = best_focus
         self.set_manual_focus(best_focus)

--- a/pyro_camera_api/pyro_camera_api/camera/base.py
+++ b/pyro_camera_api/pyro_camera_api/camera/base.py
@@ -12,6 +12,10 @@ from typing import Dict, List, Optional
 from PIL import Image
 
 
+class FocusAbortedError(Exception):
+    """Raised inside focus_finder when the caller requests an early abort."""
+
+
 class BaseCamera(ABC):
     """
     Abstract base class for all camera types.

--- a/pyro_camera_api/pyro_camera_api/camera/focus_manager.py
+++ b/pyro_camera_api/pyro_camera_api/camera/focus_manager.py
@@ -46,6 +46,11 @@ def cancel_focus_and_wait(camera_id: str, timeout: float = FOCUS_CANCEL_TIMEOUT)
     Sets the per-camera cancel event (polled between steps by the focus
     search) then waits for MOVE_LOCKS to be free, which also covers the final
     focus restoration. Returns True when the camera is free.
+
+    On success the cancel event stays set so no new focus search can start
+    before the stream pipeline is registered as active: the caller must clear
+    FOCUS_CANCEL_EVENTS[camera_id] once the stream is visible (or on failure).
+    On timeout the event is cleared here, since the stream is being refused.
     """
     event = FOCUS_CANCEL_EVENTS[camera_id]
     event.set()
@@ -53,5 +58,6 @@ def cancel_focus_and_wait(camera_id: str, timeout: float = FOCUS_CANCEL_TIMEOUT)
     acquired = lock.acquire(timeout=timeout)
     if acquired:
         lock.release()
-    event.clear()
+    else:
+        event.clear()
     return acquired

--- a/pyro_camera_api/pyro_camera_api/camera/focus_manager.py
+++ b/pyro_camera_api/pyro_camera_api/camera/focus_manager.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2022-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+"""Cooperative cancellation of the autofocus search.
+
+The autofocus search (adapter focus_finder) sweeps the focus motor for
+minutes while holding the per-camera move lock. Live streaming has priority:
+stream startup sets the per-camera cancel event so a running search aborts at
+its next step and restores the pre-search focus, then waits for the move lock
+to be released before starting the pipeline, so the viewer never sees a
+focus sweep.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from pyro_camera_api.camera.registry import FOCUS_CANCEL_EVENTS, MOVE_LOCKS
+from pyro_camera_api.services.stream import is_camera_streaming
+
+logger = logging.getLogger(__name__)
+
+# Seconds stream startup waits for a running focus operation to abort
+FOCUS_CANCEL_TIMEOUT = 20.0
+
+
+def stream_is_active(camera_id: str) -> bool:
+    """True if a live pipeline or ffmpeg restream is running for this camera."""
+    return is_camera_streaming(camera_id)
+
+
+def focus_abort_requested(camera_id: str) -> bool:
+    """Combined abort predicate: stream start pending or stream active."""
+    if FOCUS_CANCEL_EVENTS[camera_id].is_set():
+        return True
+    return stream_is_active(camera_id)
+
+
+def cancel_focus_and_wait(camera_id: str, timeout: float = FOCUS_CANCEL_TIMEOUT) -> bool:
+    """
+    Ask any running focus operation on this camera to abort and wait for it.
+
+    Sets the per-camera cancel event (polled between steps by the focus
+    search) then waits for MOVE_LOCKS to be free, which also covers the final
+    focus restoration. Returns True when the camera is free.
+    """
+    event = FOCUS_CANCEL_EVENTS[camera_id]
+    event.set()
+    lock = MOVE_LOCKS[camera_id]
+    acquired = lock.acquire(timeout=timeout)
+    if acquired:
+        lock.release()
+    event.clear()
+    return acquired

--- a/pyro_camera_api/pyro_camera_api/camera/patrol.py
+++ b/pyro_camera_api/pyro_camera_api/camera/patrol.py
@@ -12,12 +12,16 @@ import time
 from typing import Any, Dict
 
 from pyro_camera_api.camera.registry import CAMERA_REGISTRY
+from pyro_camera_api.services.stream import is_camera_streaming
 
 logger = logging.getLogger(__name__)
 
 # backoff settings for static cameras
 MAX_FAILS_BEFORE_SKIP = 2  # skip after 2 consecutive failures
 SKIP_DURATION = 30 * 60.0  # skip for 30 minutes
+
+# seconds between stream re-checks while the patrol is paused by a live stream
+STREAM_CHECK_INTERVAL = 5.0
 
 # per camera state for the static loop
 FAILURE_COUNT: Dict[str, int] = {}
@@ -75,10 +79,17 @@ def patrol_loop(camera_ip: str, stop_flag: threading.Event) -> None:
     logger.info("[%s] Starting patrol cycle with %d poses", camera_ip, len(poses))
 
     while not stop_flag.is_set():
+        # Live stream has priority: hold the patrol while a stream is active
+        # so the camera never moves under the viewer, and resume automatically
+        # once the stream stops (the thread keeps running, patrol stays "on").
+        if is_camera_streaming(camera_ip):
+            stop_flag.wait(STREAM_CHECK_INTERVAL)
+            continue
+
         start_time = time.time()
 
         for pose in poses:
-            if stop_flag.is_set():
+            if stop_flag.is_set() or is_camera_streaming(camera_ip):
                 break
 
             try:
@@ -94,6 +105,11 @@ def patrol_loop(camera_ip: str, stop_flag: threading.Event) -> None:
             except Exception as exc:
                 logger.error("[%s] Error at pose %s: %s", camera_ip, pose, exc)
                 continue
+
+        if is_camera_streaming(camera_ip):
+            # Skip the return-to-pose-0 move and focus restore during a
+            # stream, the pause at the top of the loop takes over
+            continue
 
         try:
             cam.move_camera("ToPos", idx=poses[0], speed=50)

--- a/pyro_camera_api/pyro_camera_api/camera/pose_azimuths.py
+++ b/pyro_camera_api/pyro_camera_api/camera/pose_azimuths.py
@@ -110,7 +110,10 @@ def azimuth_sync_loop(stop_flag: threading.Event) -> None:
                 logger.info(
                     "[%s] Pose azimuths resolved from platform API: %s",
                     key,
-                    dict(zip(cam.cam_poses, cam.cam_azimuths, strict=True)),
+                    # No zip(strict=): the runtime is Python 3.9 (Docker image)
+                    # and resolve_camera_azimuths already refuses partial
+                    # mappings, so the lists are same-length here.
+                    dict(zip(cam.cam_poses, cam.cam_azimuths)),  # noqa: B905
                 )
 
         stop_flag.wait(RETRY_INTERVAL_S)

--- a/pyro_camera_api/pyro_camera_api/camera/registry.py
+++ b/pyro_camera_api/pyro_camera_api/camera/registry.py
@@ -69,6 +69,11 @@ MOVE_LOCKS: Dict[str, threading.Lock] = defaultdict(threading.Lock)
 # clear. Handlers clear the event when they start a new blocking op.
 STOP_EVENTS: Dict[str, threading.Event] = defaultdict(threading.Event)
 
+# Per-camera focus cancellation events. Stream startup sets the event so any
+# running focus search aborts at its next step, then waits for MOVE_LOCKS to
+# be free before starting the pipeline (see focus_manager.cancel_focus_and_wait).
+FOCUS_CANCEL_EVENTS: Dict[str, threading.Event] = defaultdict(threading.Event)
+
 
 def build_camera_object(key: str, conf: dict) -> Optional[BaseCamera]:
     """

--- a/pyro_camera_api/pyro_camera_api/services/stream.py
+++ b/pyro_camera_api/pyro_camera_api/services/stream.py
@@ -49,6 +49,25 @@ def set_app_for_stream(app: "FastAPI") -> None:
     _APP = app
 
 
+def is_camera_streaming(camera_id: str, app: Optional["FastAPI"] = None) -> bool:
+    """
+    True if a live pipeline or ffmpeg restream is running for this camera.
+
+    Single source of truth for stream-activity checks. Uses the app stored by
+    set_app_for_stream when none is passed, so it works outside request context.
+    """
+    app = app if app is not None else _APP
+    if app is None:
+        return False
+    try:
+        if is_pipeline_running(get_workers(app).get(camera_id)):
+            return True
+        return is_process_running(get_processes(app).get(camera_id))
+    except Exception as exc:
+        logger.debug("Could not check stream state for %s: %s", camera_id, exc)
+        return False
+
+
 def get_workers(app: "FastAPI") -> dict[str, Pipeline]:
     """Return the mapping camera_id -> Pipeline from app.state."""
     return cast(dict[str, Pipeline], getattr(app.state, "stream_workers", {}))

--- a/pyro_camera_api/tests/test_focus_cancel.py
+++ b/pyro_camera_api/tests/test_focus_cancel.py
@@ -1,0 +1,193 @@
+# Copyright (C) 2022-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+import numpy as np
+import pytest
+from fastapi import HTTPException
+from PIL import Image
+
+from pyro_camera_api.api import routes_focus
+from pyro_camera_api.api.routes_focus import run_focus_optimization
+from pyro_camera_api.camera.adapters.mock import MockCamera
+from pyro_camera_api.camera.adapters.reolink import ReolinkCamera
+from pyro_camera_api.camera.base import FocusAbortedError
+from pyro_camera_api.camera.focus_manager import cancel_focus_and_wait, focus_abort_requested
+from pyro_camera_api.camera.registry import CAMERA_REGISTRY, FOCUS_CANCEL_EVENTS, MOVE_LOCKS
+
+
+def _test_image(size=(64, 64)):
+    rng = np.random.default_rng(0)
+    arr = rng.integers(0, 255, (size[1], size[0], 3), dtype=np.uint8)
+    return Image.fromarray(arr, "RGB")
+
+
+class OfflineReolink(ReolinkCamera):
+    """Reolink adapter with network calls stubbed out for tests."""
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            camera_id=kwargs.pop("camera_id", "reolink-test"),
+            ip_address="192.0.2.1",
+            username="user",
+            password="pwd",  # noqa: S106
+            **kwargs,
+        )
+        self.focus_history = []
+
+    def set_manual_focus(self, position: int):
+        self.focus_position = position
+        self.focus_history.append(position)
+
+    def capture(self, patrol_id=None, timeout=2):
+        _ = patrol_id, timeout
+        return _test_image()
+
+    def get_focus_level(self):
+        return {"focus": 720, "zoom": 0}
+
+    def start_zoom_focus(self, position: int):
+        _ = position
+
+
+@pytest.fixture(autouse=True)
+def fast_sleep(monkeypatch):
+    monkeypatch.setattr("pyro_camera_api.camera.adapters.reolink.time.sleep", lambda _s: None)
+
+
+# ---------------------------------------------------------------------------
+# cancel_focus_and_wait
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_focus_and_wait_free_camera():
+    cam_id = "cancel-free"
+    assert cancel_focus_and_wait(cam_id, timeout=0.2)
+    assert not FOCUS_CANCEL_EVENTS[cam_id].is_set()
+
+
+def test_cancel_focus_and_wait_busy_camera():
+    cam_id = "cancel-busy"
+    lock = MOVE_LOCKS[cam_id]
+    assert lock.acquire(blocking=False)
+    try:
+        assert not cancel_focus_and_wait(cam_id, timeout=0.2)
+    finally:
+        lock.release()
+    assert not FOCUS_CANCEL_EVENTS[cam_id].is_set()
+
+
+def test_focus_abort_requested_on_cancel_event():
+    cam_id = "abort-event"
+    assert not focus_abort_requested(cam_id)
+    FOCUS_CANCEL_EVENTS[cam_id].set()
+    try:
+        assert focus_abort_requested(cam_id)
+    finally:
+        FOCUS_CANCEL_EVENTS[cam_id].clear()
+
+
+# ---------------------------------------------------------------------------
+# focus_finder abort behavior
+# ---------------------------------------------------------------------------
+
+
+def test_reolink_focus_finder_aborts_and_restores_focus(monkeypatch):
+    cam = OfflineReolink(focus_position=700)
+    captures: list[int] = []
+
+    def abort_after_three() -> bool:
+        return len(captures) >= 3
+
+    real_capture = cam.capture
+
+    def counting_capture(patrol_id=None, timeout=2):
+        captures.append(1)
+        return real_capture(patrol_id=patrol_id, timeout=timeout)
+
+    monkeypatch.setattr(cam, "capture", counting_capture)
+
+    with pytest.raises(FocusAbortedError):
+        cam.focus_finder(should_abort=abort_after_three)
+
+    # Lens back on the pre-search position, reference untouched
+    assert cam.focus_history[-1] == 700
+    assert cam.focus_position == 700
+
+
+def test_reolink_focus_finder_abort_without_prior_reference():
+    cam = OfflineReolink(focus_position=None)
+
+    with pytest.raises(FocusAbortedError):
+        cam.focus_finder(should_abort=lambda: True)
+
+    # No reference must be stored by an aborted search
+    assert cam.focus_position is None
+
+
+def test_reolink_focus_finder_completes_without_abort():
+    cam = OfflineReolink(focus_position=700)
+    best = cam.focus_finder()
+    assert cam.focus_position == best
+
+
+def test_mock_focus_finder_aborts():
+    cam = MockCamera(camera_id="mock-abort", cam_type="ptz")
+    with pytest.raises(FocusAbortedError):
+        cam.focus_finder(should_abort=lambda: True)
+
+
+# ---------------------------------------------------------------------------
+# /focus/focus_finder route
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def registered_mock_camera():
+    cam_id = "route-focus"
+    cam = MockCamera(camera_id=cam_id, cam_type="ptz", cam_poses=[0, 1], focus_position=700)
+    cam._cached_image = _test_image()
+    CAMERA_REGISTRY[cam_id] = cam
+    yield cam_id, cam
+    CAMERA_REGISTRY.pop(cam_id, None)
+
+
+def test_route_refuses_when_stream_active(registered_mock_camera, monkeypatch):
+    cam_id, _cam = registered_mock_camera
+    monkeypatch.setattr(routes_focus, "stream_is_active", lambda _ip: True)
+    with pytest.raises(HTTPException) as exc:
+        run_focus_optimization(cam_id)
+    assert exc.value.status_code == 409
+
+
+def test_route_refuses_when_camera_busy(registered_mock_camera):
+    cam_id, _cam = registered_mock_camera
+    lock = MOVE_LOCKS[cam_id]
+    assert lock.acquire(blocking=False)
+    try:
+        with pytest.raises(HTTPException) as exc:
+            run_focus_optimization(cam_id)
+    finally:
+        lock.release()
+    assert exc.value.status_code == 409
+
+
+def test_route_aborts_when_cancel_event_set(registered_mock_camera):
+    cam_id, _cam = registered_mock_camera
+    FOCUS_CANCEL_EVENTS[cam_id].set()
+    try:
+        with pytest.raises(HTTPException) as exc:
+            run_focus_optimization(cam_id)
+    finally:
+        FOCUS_CANCEL_EVENTS[cam_id].clear()
+    assert exc.value.status_code == 409
+    assert not MOVE_LOCKS[cam_id].locked()
+
+
+def test_route_runs_and_releases_lock(registered_mock_camera):
+    cam_id, _cam = registered_mock_camera
+    result = run_focus_optimization(cam_id)
+    assert result["best_focus_position"] == 700
+    assert not MOVE_LOCKS[cam_id].locked()

--- a/pyro_camera_api/tests/test_focus_cancel.py
+++ b/pyro_camera_api/tests/test_focus_cancel.py
@@ -65,7 +65,10 @@ def fast_sleep(monkeypatch):
 def test_cancel_focus_and_wait_free_camera():
     cam_id = "cancel-free"
     assert cancel_focus_and_wait(cam_id, timeout=0.2)
-    assert not FOCUS_CANCEL_EVENTS[cam_id].is_set()
+    # The event stays set so no focus search can start before the stream
+    # pipeline is registered; the caller clears it afterwards.
+    assert FOCUS_CANCEL_EVENTS[cam_id].is_set()
+    FOCUS_CANCEL_EVENTS[cam_id].clear()
 
 
 def test_cancel_focus_and_wait_busy_camera():
@@ -115,6 +118,18 @@ def test_reolink_focus_finder_aborts_and_restores_focus(monkeypatch):
     # Lens back on the pre-search position, reference untouched
     assert cam.focus_history[-1] == 700
     assert cam.focus_position == 700
+
+
+def test_reolink_focus_finder_abort_restores_unclamped_focus():
+    # A configured focus outside the [600, 900] search interval must be
+    # restored as-is, not clamped, so the lens matches the cached reference
+    cam = OfflineReolink(focus_position=950)
+
+    with pytest.raises(FocusAbortedError):
+        cam.focus_finder(should_abort=lambda: True)
+
+    assert cam.focus_history[-1] == 950
+    assert cam.focus_position == 950
 
 
 def test_reolink_focus_finder_abort_without_prior_reference():

--- a/pyro_camera_api/tests/test_patrol_stream.py
+++ b/pyro_camera_api/tests/test_patrol_stream.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2022-2026, Pyronear.
+
+# This program is licensed under the Apache License 2.0.
+# See LICENSE or go to <https://opensource.org/licenses/Apache-2.0> for full license details.
+
+
+import threading
+
+from PIL import Image
+
+from pyro_camera_api.camera import patrol
+from pyro_camera_api.camera.adapters.mock import MockCamera
+from pyro_camera_api.camera.registry import CAMERA_REGISTRY
+
+
+def test_patrol_loop_pauses_while_streaming(monkeypatch):
+    cam_id = "patrol-stream"
+    cam = MockCamera(camera_id=cam_id, cam_type="ptz", cam_poses=[0, 1])
+    cam._cached_image = Image.new("RGB", (8, 8))
+    CAMERA_REGISTRY[cam_id] = cam
+    try:
+        monkeypatch.setattr(patrol, "STREAM_CHECK_INTERVAL", 0.01)
+        monkeypatch.setattr(patrol.time, "sleep", lambda _s: None)
+
+        streaming = {"on": True}
+        monkeypatch.setattr(patrol, "is_camera_streaming", lambda _ip: streaming["on"])
+
+        moved = threading.Event()
+        real_move = cam.move_camera
+
+        def tracking_move(*args, **kwargs):
+            moved.set()
+            return real_move(*args, **kwargs)
+
+        monkeypatch.setattr(cam, "move_camera", tracking_move)
+
+        stop = threading.Event()
+        thread = threading.Thread(target=patrol.patrol_loop, args=(cam_id, stop), daemon=True)
+        thread.start()
+
+        # While a stream is active the patrol must not move the camera
+        assert not moved.wait(0.3)
+
+        # As soon as the stream stops, the patrol resumes on its own
+        streaming["on"] = False
+        assert moved.wait(2.0)
+
+        stop.set()
+        thread.join(timeout=2.0)
+        assert not thread.is_alive()
+    finally:
+        CAMERA_REGISTRY.pop(cam_id, None)


### PR DESCRIPTION
- The autofocus search is a minutes-long sweep that nothing could interrupt: a viewer starting a live stream during the search got a blurry, sweeping image.
- `/stream/start_stream` now cancels any running focus search on the camera and waits for the lens to be restored before starting the pipeline; `/focus/focus_finder` is refused (409) while a stream is active and aborts if a stream starts mid-search.
- Minimal extraction from #391 (same naming), so #391 can rebase on top; no engine change needed, the engine retries the hourly autofocus later on 409.