### PR TITLE
fix(engine): send empty bboxes and unblock the alert upload queue

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -25,6 +25,9 @@ from requests.models import Response
 
 __all__ = ["ContextCrop", "Engine"]
 
+# Client errors worth retrying later; every other 4xx is a permanent rejection of the payload.
+RETRYABLE_STATUS = frozenset({408, 425, 429})
+
 logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
 
@@ -705,17 +708,26 @@ class Engine(Predictor):
                         jpeg_bytes, bboxes, pose_id, crops=crops, recorded_at=frame_info["ts"]
                     )
 
-                    try:
-                        response.json()["id"]
-                    except ValueError:
-                        logger.error(f"Camera '{cam_id}' - non-JSON response body: {response.text}")
-                        raise
+                    if response.status_code >= 500 or response.status_code in RETRYABLE_STATUS:
+                        raise RequestException(f"API error {response.status_code}: {response.text}")
 
-                    # Clear
+                    # Anything else is final: either the alert was stored (201, or 204 for a frame
+                    # with no detection extending no sequence) or the API rejected it for good.
+                    # Keeping a rejected alert would only replay the same failure and block the
+                    # whole queue behind it.
+                    if 200 <= response.status_code < 300:
+                        logger.info(f"Camera '{cam_id}' - alert sent")
+                    else:
+                        logger.error(f"Camera '{cam_id}' - alert rejected ({response.status_code}): {response.text}")
                     self._alerts.popleft()
-                    logger.info(f"Camera '{cam_id}' - alert sent")
 
-                except (KeyError, RequestsConnectionError, ValueError) as e:
+                except ValueError as e:
+                    # The client refused to serialize the payload, so a retry cannot help either.
+                    logger.error(f"Camera '{cam_id}' - invalid alert payload, dropping it")
+                    logger.error(e)
+                    self._alerts.popleft()
+
+                except (KeyError, RequestException) as e:
                     logger.error(f"Camera '{cam_id}' - unable to upload cache")
                     logger.error(e)
                     break

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -25,9 +25,6 @@ from requests.models import Response
 
 __all__ = ["ContextCrop", "Engine"]
 
-# Degenerate bbox stamped on alerts with no detection so the upload payload is never empty.
-PLACEHOLDER_BBOX = (0.0, 0.0, 0.0001, 0.0001, 0.0)
-
 logging.basicConfig(format="%(asctime)s | %(levelname)s: %(message)s", level=logging.INFO, force=True)
 logger = logging.getLogger(__name__)
 
@@ -593,9 +590,6 @@ class Engine(Predictor):
         """Cut one 224x224 JPEG per bbox out of the context crop, using the frozen event crop boxes."""
         if context_crop is None or not bboxes or not crop_boxes or len(crop_boxes) != len(bboxes):
             return None
-        # Placeholder-only alerts carry no real detection, so they upload no crops.
-        if all(tuple(bbox) == PLACEHOLDER_BBOX for bbox in bboxes):
-            return None
         region = Image.open(io.BytesIO(context_crop.jpeg))
         region_w, region_h = region.size
         # The stored region may be downscaled, so map full-frame crop boxes through the actual
@@ -675,16 +669,8 @@ class Engine(Predictor):
             "crop_boxes": crop_boxes,
         })
 
-    def fill_empty_bboxes(self) -> None:
-        # Stamp a tiny placeholder bbox at conf=0 on any alert with none,
-        # so the upload guard always sees a non-empty payload.
-        for alert in self._alerts:
-            if not alert["bboxes"]:
-                alert["bboxes"] = [PLACEHOLDER_BBOX]
-
     def _process_alerts(self) -> None:
         if self.cam_creds is not None:
-            self.fill_empty_bboxes()
             for _ in range(len(self._alerts)):
                 # try to upload the oldest element
                 frame_info = self._alerts[0]
@@ -700,12 +686,9 @@ class Engine(Predictor):
                     )
 
                 try:
-                    # Detection creation
+                    # Detection creation. An empty bbox list is a frame with no detection: the
+                    # API attaches it to the ongoing sequences of the pose, or answers 204.
                     bboxes = self._alerts[0]["bboxes"]
-                    if not bboxes:
-                        logger.warning(f"Camera '{cam_id}' - skipping alert with empty bboxes")
-                        self._alerts.popleft()
-                        continue
                     jpeg_bytes = frame_info.get("jpeg_bytes")
                     if jpeg_bytes is None:
                         # The full frame is no longer kept in RAM, so there is nothing to re-encode.

--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -711,13 +711,20 @@ class Engine(Predictor):
                     if response.status_code >= 500 or response.status_code in RETRYABLE_STATUS:
                         raise RequestException(f"API error {response.status_code}: {response.text}")
 
-                    # Anything else is final: either the alert was stored (201, or 204 for a frame
-                    # with no detection extending no sequence) or the API rejected it for good.
-                    # Keeping a rejected alert would only replay the same failure and block the
-                    # whole queue behind it.
                     if 200 <= response.status_code < 300:
+                        # A 204 answers a frame with no detection that extended no sequence:
+                        # nothing was stored, so there is no detection id to look for.
+                        if response.status_code != 204:
+                            try:
+                                response.json()["id"]
+                            except (ValueError, KeyError, TypeError):
+                                raise RequestException(
+                                    f"success {response.status_code} without a detection id: {response.text}"
+                                ) from None
                         logger.info(f"Camera '{cam_id}' - alert sent")
                     else:
+                        # Rejected for good: keeping the alert would only replay the same failure
+                        # and block the whole queue behind it.
                         logger.error(f"Camera '{cam_id}' - alert rejected ({response.status_code}): {response.text}")
                     self._alerts.popleft()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -469,7 +469,7 @@ def _build_engine_with_fake_client(tmp_path):
     engine = Engine(cache_folder=str(tmp_path))
     engine.cam_creds = {cam_id: ("dummy_token", 3)}
     fake_client = MagicMock()
-    fake_client.create_detection.return_value = MagicMock(json=MagicMock(return_value={"id": 1}))
+    fake_client.create_detection.return_value = MagicMock(status_code=201)
     engine.api_client = {"169.254.7.3": fake_client}
     return engine, fake_client, cam_id
 
@@ -508,6 +508,59 @@ def test_process_alerts_empty_bboxes_uploaded_as_is(tmp_path):
     assert fake_client.create_detection.call_args.args[1] == []
     assert fake_client.create_detection.call_args.kwargs["crops"] is None
     assert len(engine._alerts) == 0
+
+
+def _stage_dummy_alert(engine, cam_id, ts="2026-07-21T12:00:00.000000+00:00"):
+    buf = io.BytesIO()
+    Image.new("RGB", (640, 480)).save(buf, format="JPEG")
+    engine._stage_alert(None, cam_id, ts, bboxes=[], jpeg_bytes=buf.getvalue())
+
+
+def test_process_alerts_no_content_response_clears_alert(tmp_path):
+    """204 (frame with no detection extending no sequence) has no body and must not block."""
+    engine, fake_client, cam_id = _build_engine_with_fake_client(tmp_path)
+    fake_client.create_detection.return_value = MagicMock(status_code=204)
+    _stage_dummy_alert(engine, cam_id)
+
+    engine._process_alerts()
+
+    assert len(engine._alerts) == 0
+
+
+def test_process_alerts_drops_alert_on_rejection(tmp_path):
+    """A rejected alert is dropped so the alerts queued behind it still get uploaded."""
+    engine, fake_client, cam_id = _build_engine_with_fake_client(tmp_path)
+    fake_client.create_detection.return_value = MagicMock(status_code=422, text="invalid bbox")
+    _stage_dummy_alert(engine, cam_id)
+    _stage_dummy_alert(engine, cam_id, "2026-07-21T12:00:01.000000+00:00")
+
+    engine._process_alerts()
+
+    assert fake_client.create_detection.call_count == 2
+    assert len(engine._alerts) == 0
+
+
+def test_process_alerts_drops_alert_on_client_side_value_error(tmp_path):
+    """A payload the client refuses to serialize can never be uploaded, so it is dropped."""
+    engine, fake_client, cam_id = _build_engine_with_fake_client(tmp_path)
+    fake_client.create_detection.side_effect = ValueError("coordinates are expected to be relative")
+    _stage_dummy_alert(engine, cam_id)
+
+    engine._process_alerts()
+
+    assert len(engine._alerts) == 0
+
+
+@pytest.mark.parametrize("status_code", [503, 429])
+def test_process_alerts_keeps_alert_on_retryable_error(tmp_path, status_code):
+    """Retryable statuses keep the alert cached and stop the loop until the next pass."""
+    engine, fake_client, cam_id = _build_engine_with_fake_client(tmp_path)
+    fake_client.create_detection.return_value = MagicMock(status_code=status_code, text="try later")
+    _stage_dummy_alert(engine, cam_id)
+
+    engine._process_alerts()
+
+    assert len(engine._alerts) == 1
 
 
 def _build_engine_with_pose_stub(tmp_path, init_clock):

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -12,7 +12,7 @@ import pytest
 from dotenv import load_dotenv
 from PIL import Image
 
-from pyroengine.engine import CONTEXT_MAX_SIDE, PLACEHOLDER_BBOX, ContextCrop, Engine
+from pyroengine.engine import CONTEXT_MAX_SIDE, ContextCrop, Engine
 
 
 def test_engine_offline(tmpdir_factory, mock_wildfire_image, mock_forest_image):
@@ -225,45 +225,6 @@ def test_process_alerts_respects_save_detections_flag(tmp_path, save_detections_
     if len(engine._alerts) > 0:
         pytest.skip("Detection upload failed, alert left in cache")
     assert len(engine._alerts) == 0
-
-
-def test_fill_empty_bboxes(tmp_path):
-    """fill_empty_bboxes stamps a placeholder bbox at conf=0 on any empty alert
-    and leaves non-empty alerts untouched."""
-    engine = Engine(cache_folder=str(tmp_path))
-
-    cam_id = "169.254.7.3_3"
-    bboxes_seq = [
-        [(0.436, 0.609, 0.44, 0.62, 0.089)],
-        [(0.436, 0.609, 0.44, 0.62, 0.589)],
-        [(0.436, 0.609, 0.44, 0.62, 0.489)],
-        [],  # empty middle frame
-        [(0.436, 0.609, 0.44, 0.62, 0.689)],
-        [(0.436, 0.609, 0.44, 0.62, 0.389)],
-    ]
-    for i, bboxes in enumerate(bboxes_seq):
-        engine._stage_alert(None, cam_id, i, bboxes=bboxes)
-
-    engine.fill_empty_bboxes()
-
-    assert all(alert["bboxes"] for alert in engine._alerts)
-    # Previously-empty frame gets the placeholder bbox at conf=0
-    assert engine._alerts[3]["bboxes"] == [(0.0, 0.0, 0.0001, 0.0001, 0.0)]
-    # Non-empty frames untouched
-    assert engine._alerts[0]["bboxes"][0][4] == pytest.approx(0.089)
-    assert engine._alerts[5]["bboxes"][0][4] == pytest.approx(0.389)
-
-
-def test_fill_empty_bboxes_all_empty_for_cam(tmp_path):
-    """Even when every alert for a cam_id is empty, each one gets the placeholder."""
-    engine = Engine(cache_folder=str(tmp_path))
-
-    for i in range(3):
-        engine._stage_alert(None, "169.254.7.3_3", i, bboxes=[])
-
-    engine.fill_empty_bboxes()
-
-    assert all(alert["bboxes"] == [(0.0, 0.0, 0.0001, 0.0001, 0.0)] for alert in engine._alerts)
 
 
 def test_build_context_crop(tmp_path):
@@ -503,33 +464,6 @@ def test_encode_detection_crops_one_per_bbox(tmp_path):
     assert engine._encode_detection_crops(None, bboxes, crop_boxes) is None
 
 
-def test_encode_detection_crops_placeholder_returns_none(tmp_path):
-    engine = Engine(cache_folder=str(tmp_path))
-    frame = Image.new("RGB", (640, 480))
-    context = engine._build_context_crop(frame, np.array([[0.5, 0.5, 0.7, 0.7, 0.6]]))
-    box = engine._compute_crop_box([PLACEHOLDER_BBOX], 640, 480)
-
-    assert engine._encode_detection_crops(context, [PLACEHOLDER_BBOX], [box]) is None
-    assert engine._encode_detection_crops(context, [], None) is None
-    # List-form placeholder (not a tuple) must still be treated as placeholder-only
-    assert engine._encode_detection_crops(context, [list(PLACEHOLDER_BBOX)], [box]) is None
-
-
-def test_encode_detection_crops_mixed_placeholder_and_real_bbox(tmp_path):
-    """A placeholder mixed with a real bbox still yields one crop per bbox, not None."""
-    engine = Engine(cache_folder=str(tmp_path))
-    frame = Image.new("RGB", (640, 480))
-    bboxes = [PLACEHOLDER_BBOX, (0.5, 0.5, 0.7, 0.7, 0.6)]
-    context = engine._build_context_crop(frame, np.array([list(b) for b in bboxes]))
-    crop_boxes = [engine._compute_crop_box([b], 640, 480) for b in bboxes]
-
-    crops = engine._encode_detection_crops(context, bboxes, crop_boxes)
-
-    assert crops is not None
-    assert len(crops) == len(bboxes)
-    assert all(isinstance(c, bytes) for c in crops)
-
-
 def _build_engine_with_fake_client(tmp_path):
     cam_id = "169.254.7.3_3"
     engine = Engine(cache_folder=str(tmp_path))
@@ -561,16 +495,17 @@ def test_process_alerts_sends_one_crop_per_bbox(tmp_path):
     assert len(engine._alerts) == 0
 
 
-def test_process_alerts_placeholder_bbox_sends_no_crop(tmp_path):
+def test_process_alerts_empty_bboxes_uploaded_as_is(tmp_path):
+    """A frame with no detection is uploaded with an empty bbox list and no crop."""
     engine, fake_client, cam_id = _build_engine_with_fake_client(tmp_path)
     buf = io.BytesIO()
     Image.new("RGB", (640, 480)).save(buf, format="JPEG")
-    # Empty bboxes -> fill_empty_bboxes stamps the placeholder; no context crop / crop boxes.
     engine._stage_alert(None, cam_id, "2026-07-21T12:00:00.000000+00:00", bboxes=[], jpeg_bytes=buf.getvalue())
 
     engine._process_alerts()
 
     assert fake_client.create_detection.call_count == 1
+    assert fake_client.create_detection.call_args.args[1] == []
     assert fake_client.create_detection.call_args.kwargs["crops"] is None
     assert len(engine._alerts) == 0
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -551,6 +551,19 @@ def test_process_alerts_drops_alert_on_client_side_value_error(tmp_path):
     assert len(engine._alerts) == 0
 
 
+def test_process_alerts_keeps_alert_on_success_without_detection_id(tmp_path):
+    """A 2xx whose body carries no detection id means nothing was stored: keep the alert."""
+    engine, fake_client, cam_id = _build_engine_with_fake_client(tmp_path)
+    fake_client.create_detection.return_value = MagicMock(
+        status_code=200, text="<html>proxy</html>", json=MagicMock(side_effect=ValueError)
+    )
+    _stage_dummy_alert(engine, cam_id)
+
+    engine._process_alerts()
+
+    assert len(engine._alerts) == 1
+
+
 @pytest.mark.parametrize("status_code", [503, 429])
 def test_process_alerts_keeps_alert_on_retryable_error(tmp_path, status_code):
     """Retryable statuses keep the alert cached and stop the loop until the next pass."""


### PR DESCRIPTION
Fixes #402.

- Frames with no detection were stamped with a placeholder bbox `(0, 0, 0.0001, 0.0001, 0)`. pyroclient serializes coordinates with 3 decimals, so `xmin == xmax` and the API rejects the alert with a 422. Since pyro-api #624 those frames are reported with an empty bbox list, which the API attaches to the ongoing sequences of the pose (or answers 204).
- The upload result was read as `response.json()["id"]`, so a rejection surfaced as a bare `KeyError` with no status code and no body, and the `break` replayed the same doomed alert forever, stalling every alert queued behind it. The status code is now checked: retry on 5xx and on 408/425/429, drop and log status plus body on any other non-2xx, accept 204 without a body.
- A `ValueError` raised by the client while serializing the payload is final too, so the alert is dropped rather than retried indefinitely.
- A 2xx whose body carries no detection id keeps the alert cached: the detection was not stored.