### PR TITLE
ci(release): add a catch-all category to the release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -22,3 +22,8 @@ changelog:
     - title: Miscellaneous
       labels:
         - "type: misc"
+    # EVERYTHING ELSE
+    # Without this catch-all, unlabeled PRs match no category and GitHub
+    # drops them, which leaves the generated release notes empty.
+    - title: Other changes
+      labels: ["*"]


### PR DESCRIPTION
- `.github/release.yml` defined five label-based categories and no catch-all, so GitHub dropped every PR matching none of them. Since engine PRs carry no labels, the generated notes came out empty, as in v1.0.18.
- Adds `- title: Other changes` / `labels: ["*"]` after the specific categories, which is what pyro-api does. Existing categories keep their precedence.
- Config only, effective on the next release cut from `develop`.

Checked with GitHub's own generator over the same range (`v1.0.17..HEAD`): empty body with the config on `develop`, PRs listed under "Other changes" with the config on this branch.