### PR TITLE
feat(engine): one heartbeat per camera per minute

### DIFF
--- a/pyroengine/engine.py
+++ b/pyroengine/engine.py
@@ -139,6 +139,7 @@ class Engine(Predictor):
         save_captured_frames: Optional[bool] = False,
         save_detections_frames: Optional[bool] = False,
         send_last_image_period: int = 3600,  # 1H
+        heartbeat_period: int = 60,  # 1 min
         last_bbox_mask_fetch_period: int = 3600,  # 1H
         **kwargs: Any,  # noqa: ANN401
     ) -> None:
@@ -172,6 +173,8 @@ class Engine(Predictor):
         self.save_detections_frames = save_detections_frames
         self.cam_creds = cam_creds
         self.send_last_image_period = send_last_image_period
+        self.heartbeat_period = heartbeat_period
+        self._last_heartbeat: Dict[str, float] = {}  # camera ip -> time.monotonic() of the last attempt
         self.last_bbox_mask_fetch_period = last_bbox_mask_fetch_period
 
         # Local backup
@@ -266,7 +269,12 @@ class Engine(Predictor):
 
         # Heartbeat
         if len(self.api_client) > 0 and isinstance(cam_id, str):
-            heartbeat_with_timeout(self, cam_id, timeout=1)
+            # One heartbeat per camera, not per pose: liveness only needs minute-level resolution and
+            # heartbeats were 89% of the API traffic.
+            ip = cam_id.split("_")[0]
+            if time.monotonic() - self._last_heartbeat.get(ip, float("-inf")) >= self.heartbeat_period:
+                heartbeat_with_timeout(self, cam_id, timeout=1)
+                self._last_heartbeat[ip] = time.monotonic()
             if (
                 self._states[cam_key]["last_image_sent"] is None
                 or time.time() - self._states[cam_key]["last_image_sent"] > self.send_last_image_period

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -576,6 +576,33 @@ def test_process_alerts_keeps_alert_on_retryable_error(tmp_path, status_code):
     assert len(engine._alerts) == 1
 
 
+def test_heartbeat_once_per_camera_per_period(tmp_path, mock_forest_image):
+    """Poses of one camera share a heartbeat; cameras are throttled independently."""
+    cam_creds = {"10.0.0.1_0": ("tok", 0), "10.0.0.1_1": ("tok", 1), "10.0.0.2_0": ("tok", 0)}
+    fake_client = MagicMock()
+    fake_client.update_last_image.return_value = MagicMock(text="ok")
+    fake_client.list_pose_masks.return_value = MagicMock(raise_for_status=MagicMock(), json=MagicMock(return_value=[]))
+    clock = [1000.0]
+
+    with (
+        patch("pyroengine.engine.client.Client", return_value=fake_client),
+        patch("time.monotonic", side_effect=lambda: clock[0]),
+    ):
+        engine = Engine(api_url="http://stub", cache_folder=str(tmp_path), cam_creds=cam_creds, heartbeat_period=60)
+
+        for cam_id in cam_creds:
+            engine.predict(mock_forest_image, cam_id)
+        assert fake_client.heartbeat.call_count == 2  # one per camera ip
+
+        clock[0] += 30
+        engine.predict(mock_forest_image, "10.0.0.1_0")
+        assert fake_client.heartbeat.call_count == 2  # still within the period
+
+        clock[0] += 31
+        engine.predict(mock_forest_image, "10.0.0.1_1")
+        assert fake_client.heartbeat.call_count == 3  # period elapsed for 10.0.0.1 only
+
+
 def _build_engine_with_pose_stub(tmp_path, init_clock):
     """Build an Engine with the api_client stubbed and datetime.now() pinned to init_clock."""
     cam_id = "169.254.7.3_3"


### PR DESCRIPTION
- Heartbeats were sent on every pose of every loop, 8 per minute for a 4-pose camera. Fleet-wide that is 7.5 requests per second and 89% of the alert API traffic, for a liveness signal the platform only evaluates with a 30 minute threshold.
- The engine now sends at most one heartbeat per camera per `heartbeat_period` (default 60 s), tracked per camera IP on a monotonic clock. Periodic image uploads and mask fetches are unchanged.
- Cuts heartbeat traffic by roughly 8x with no API or platform change.
